### PR TITLE
Add SVC verification disable on 5.x

### DIFF
--- a/ipl/pkg1.c
+++ b/ipl/pkg1.c
@@ -90,7 +90,7 @@ PATCHSET_DEF(_kernel_4_patchset,
 );
 
 PATCHSET_DEF(_kernel_5_patchset,
-	{ 0xFFFFFFFF, 0xFFFFFFFF },  // TODO: MISSING
+	{ 0x45E6C, _NOP() },  // Disable SVC verifications
 	{ 0x5513C, _MOVZX(8, 1, 0) } // Enable Debug Patch
 );
 


### PR DESCRIPTION
At least on 5.0.0, that seems right. It's untested though.

`- 5.0.0-5.0.2   0x0004556c 00030054 => 1f2003d5 0x0004556c`