### PR TITLE
Fusee patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ OBJS = $(addprefix $(BUILD)/, \
 	clock.o \
 	cluster.o \
 	fuse.o \
+	fusee_kernel_patches.o \
 	gpio.o \
 	heap.o \
 	hos.o \

--- a/ipl/fusee_kernel_patches.c
+++ b/ipl/fusee_kernel_patches.c
@@ -1,0 +1,300 @@
+#include <string.h>
+#include <stdbool.h>
+#include "fusee_kernel_patches.h"
+
+#include "btn.h"
+#include "ff.h"
+#include "util.h"
+
+#define MAKE_BRANCH(a, o) 0x14000000 | ((((o) - (a)) >> 2) & 0x3FFFFFF)
+
+#define MAKE_KERNEL_PATTERN_NAME(vers, name) g_kernel_patch_##vers##_##name
+#define MAKE_KERNEL_HOOK_NAME(vers, name) g_kernel_hook_##vers##_##name
+
+typedef uint32_t instruction_t;
+
+typedef struct {
+    size_t pattern_size;
+    const uint8_t *pattern;
+    size_t pattern_hook_offset;
+    size_t payload_num_instructions;
+    size_t branch_back_offset;
+    const instruction_t *payload;
+} kernel_hook_t;
+
+typedef struct {
+    uint8_t hash[0x20]; /* TODO: Come up with a better way to identify kernels, that doesn't rely on hashing them. */
+    uint32_t crc32;
+    size_t free_code_space_offset;
+    unsigned int num_hooks;
+    const kernel_hook_t *hooks;
+} kernel_info_t;
+
+/* Patch definitions. */
+// NOTE: This patch stopped LayeredFS from working, and wasn't included in the distributed pre-patched kernel
+/*  
+    mov w10, w23
+    lsl x10, x10, #2
+    ldr x10, [x28, x10]
+    mov x9, #0x0000ffffffffffff
+    and x8, x10, x9
+    mov x9, #0xffff000000000000
+    and x10, x10, x9
+    mov x9, #0xfffe000000000000
+    cmp x10, x9
+    beq #12
+    ldr x10, [sp,#0xa0]
+    ldr x8, [x10,#0x2b0]
+    ldr x10, [sp,#0xa0]
+*/
+//static const uint8_t MAKE_KERNEL_PATTERN_NAME(400, proc_id_send)[] = {0xEA, 0x53, 0x40, 0xF9, 0x48, 0x59, 0x41, 0xF9, 0xE9, 0x03, 0x17, 0x2A, 0x29, 0xF5, 0x7E, 0xD3};
+//static const instruction_t MAKE_KERNEL_HOOK_NAME(400, proc_id_send)[] = {0xF9403BED, 0x2A0E03EA, 0xD37EF54A, 0xF86A69AA, 0x92FFFFE9, 0x8A090148, 0xD2FFFFE9, 0x8A09014A, 0xD2FFFFC9, 0xEB09015F, 0x54000040, 0xF9415B28, 0xD503201F};
+
+/*  
+    ldr x13, [sp,#0x70]
+    mov w10, w14
+    lsl x10, x10, #2
+    ldr x10, [x13, x10]
+    mov x9, #0x0000ffffffffffff
+    and x8, x10, x9
+    mov x9, #0xffff000000000000
+    and x10, x10, x9
+    mov x9, #0xfffe000000000000
+    cmp x10, x9
+    beq #8
+    ldr x8, [x25,#0x2b0]
+    nop
+*/
+static const uint8_t MAKE_KERNEL_PATTERN_NAME(400, proc_id_recv)[] = {0x28, 0x5B, 0x41, 0xF9, 0xE9, 0x03, 0x0E, 0x2A, 0xCE, 0x09, 0x00, 0x11, 0x29, 0xF5, 0x7E, 0xD3};
+static const instruction_t MAKE_KERNEL_HOOK_NAME(400, proc_id_recv)[] = {0xD280000D, 0x2A0E03ED, 0xD37EF5AD, 0xF86D6B4D, 0x92FFFFE9, 0x8A090148, 0xD2FFFFE9, 0x8A0901AD, 0xD2FFFFC9, 0xEB09015F, 0x54000040, 0xF9415B28, 0xD503201F};
+
+// NOTE: This patch stopped LayeredFS from working, and wasn't included in the distributed pre-patched kernel
+/*
+    mov w10, w23
+    lsl x10, x10, #2
+    ldr x10, [x27, x10]
+    mov x9, #0x0000ffffffffffff
+    and x8, x10, x9
+    mov x9, #0xffff000000000000
+    and x10, x10, x9
+    mov x9, #0xfffe000000000000
+    cmp x10, x9
+    beq #12
+    ldr x10, [sp,#0x80]
+    ldr x8, [x10,#0x2b0]
+    ldr x10, [sp,#0x80]
+*/
+//static const uint8_t MAKE_KERNEL_PATTERN_NAME(500, proc_id_send)[] = {0xEA, 0x43, 0x40, 0xF9, 0x48, 0x59, 0x41, 0xF9, 0xE9, 0x03, 0x17, 0x2A, 0x29, 0xF5, 0x7E, 0xD3};
+//static const instruction_t MAKE_KERNEL_HOOK_NAME(500, proc_id_send)[] = {0x2A1703EA, 0xD37EF54A, 0xF86A6B6A, 0x92FFFFE9, 0x8A090148, 0xD2FFFFE9, 0x8A09014A, 0xD2FFFFC9, 0xEB09015F, 0x54000060, 0xF94043EA, 0xF9415948, 0xF94043EA};
+
+/*  
+    ldr x13, [sp, #0x70]
+    mov w10, w21
+    lsl x10, x10, #2
+    ldr x10, [x13, x10]
+    mov x9, #0x0000ffffffffffff
+    and x8, x10, x9
+    mov x9, #0xffff000000000000
+    and x10, x10, x9
+    mov x9, #0xfffe000000000000
+    cmp x10, x9
+    beq #8
+    ldr x8, [x24,#0x2b0]
+    ldr x10, [sp,#0xd8] 
+*/
+static const uint8_t MAKE_KERNEL_PATTERN_NAME(500, proc_id_recv)[] = {0x08, 0x5B, 0x41, 0xF9, 0xEA, 0x6F, 0x40, 0xF9, 0xE9, 0x03, 0x15, 0x2A, 0x29, 0xF5, 0x7E, 0xD3};
+static const instruction_t MAKE_KERNEL_HOOK_NAME(500, proc_id_recv)[] = {0xF9403BED, 0x2A1503EA, 0xD37EF54A, 0xF86A69AA, 0x92FFFFE9, 0x8A090148, 0xD2FFFFE9, 0x8A09014A, 0xD2FFFFC9, 0xEB09015F, 0x54000040, 0xF9415B08, 0xF9406FEA};
+
+/* Hook Definitions. */
+static const kernel_hook_t g_kernel_hooks_100[] = {
+    /* TODO */
+};
+static const kernel_hook_t g_kernel_hooks_200[] = {
+    /* TODO */
+};
+static const kernel_hook_t g_kernel_hooks_300[] = {
+    /* TODO */
+};
+static const kernel_hook_t g_kernel_hooks_302[] = {
+    /* TODO */
+};
+static const kernel_hook_t g_kernel_hooks_400[] = {
+    // NOTE: This patch stopped LayeredFS from working, and wasn't included in the distributed pre-patched kernel
+    // {   /* Send Message Process ID Patch. */
+    //     .pattern_size = 0x10,
+    //     .pattern = MAKE_KERNEL_PATTERN_NAME(400, proc_id_send),
+    //     .pattern_hook_offset = 0x0,
+    //     .payload_num_instructions = 13,
+    //     .branch_back_offset = 0x8,
+    //     .payload = MAKE_KERNEL_HOOK_NAME(400, proc_id_send)
+    // },
+    {   /* Receive Message Process ID Patch. */
+        .pattern_size = 0x10,
+        .pattern = MAKE_KERNEL_PATTERN_NAME(400, proc_id_recv),
+        .pattern_hook_offset = 0x0,
+        .payload_num_instructions = 13,
+        .branch_back_offset = 0x4,
+        .payload = MAKE_KERNEL_HOOK_NAME(400, proc_id_recv)
+    }
+};
+static const kernel_hook_t g_kernel_hooks_500[] = {
+    // NOTE: This patch stopped LayeredFS from working, and wasn't included in the distributed pre-patched kernel
+    // {   /* Send Message Process ID Patch. */
+    //     .pattern_size = 0x10,
+    //     .pattern = MAKE_KERNEL_PATTERN_NAME(500, proc_id_send),
+    //     .pattern_hook_offset = 0x0,
+    //     .payload_num_instructions = 13,
+    //     .branch_back_offset = 0x8,
+    //     .payload = MAKE_KERNEL_HOOK_NAME(500, proc_id_send)
+    // },
+    {   /* Receive Message Process ID Patch. */
+        .pattern_size = 0x10,
+        .pattern = MAKE_KERNEL_PATTERN_NAME(500, proc_id_recv),
+        .pattern_hook_offset = 0x0,
+        .payload_num_instructions = 13,
+        .branch_back_offset = 0x8,
+        .payload = MAKE_KERNEL_HOOK_NAME(500, proc_id_recv)
+    }
+};
+
+#define KERNEL_HOOKS(vers) .num_hooks = sizeof(g_kernel_hooks_##vers)/sizeof(kernel_hook_t), .hooks = g_kernel_hooks_##vers,
+
+/* Kernel Infos. */
+static const kernel_info_t g_kernel_infos[] = {
+    {   /* 1.0.0. */
+        .crc32 = 0x427f2647,
+        .free_code_space_offset = 0x4597C,
+        KERNEL_HOOKS(100)
+    },
+    {   /* 2.0.0. */
+        /* TODO */
+        .crc32 = 0xae19cf1b,
+        .free_code_space_offset = 0,
+        KERNEL_HOOKS(200)
+    },
+    {   /* 3.0.0. */
+        .crc32 = 0x73c9e274,
+        .hash = {0x50, 0x84, 0x23, 0xAC, 0x6F, 0xA1, 0x5D, 0x3B, 0x56, 0xC2, 0xFC, 0x95, 0x22, 0xCC, 0xD5, 0xA8, 0x15, 0xD3, 0xB4, 0x6B, 0xA1, 0x2C, 0xF2, 0x93, 0xD3, 0x02, 0x05, 0xAB, 0x52, 0xEF, 0x73, 0xC5},
+        .free_code_space_offset = 0x494A4,
+        KERNEL_HOOKS(300)
+    },
+    {   /* 3.0.2. */
+        /* TODO */
+        .crc32 = 0xe0e8cdc4,
+        .free_code_space_offset = 0,
+        KERNEL_HOOKS(302)
+    },
+    {   /* 4.0.0. */
+        .crc32 = 0x485d0157,
+        .hash = {0xE6, 0xC0, 0xB7, 0xE3, 0x2F, 0xF9, 0x44, 0x51, 0xEC, 0xD5, 0x95, 0x79, 0xE3, 0x46, 0xB1, 0xDA, 0x2E, 0xD9, 0x28, 0xC6, 0xF2, 0x31, 0x4F, 0x95, 0xD8, 0xC7, 0xD5, 0xBD, 0x15, 0xD5, 0xE2, 0x5A},
+        .free_code_space_offset = 0x4FBC0,
+        KERNEL_HOOKS(400)
+    },
+    {   /* 5.0.0. */
+        .crc32 = 0xf3c363f2,
+        .hash = {0xB2, 0x38, 0x61, 0xA8, 0xE1, 0xE2, 0xE4, 0xE4, 0x17, 0x28, 0xED, 0xA9, 0xF6, 0xF6, 0xBD, 0xD2, 0x59, 0xDB, 0x1F, 0xEF, 0x4A, 0x8B, 0x2F, 0x1C, 0x64, 0x46, 0x06, 0x40, 0xF5, 0x05, 0x9C, 0x43},
+        .free_code_space_offset = 0x5C020,
+        KERNEL_HOOKS(500)
+    }
+};
+
+/* Used for halting if an error occurs in patching */
+void reboot_rcm();
+__attribute__((noreturn)) void wait_for_button_and_reboot(void) {
+    uint32_t button;
+    while (true) {
+        button = btn_read();
+        if (button & BTN_POWER) {
+            reboot_rcm();
+        }
+    }
+}
+
+/* Adapted from https://github.com/AuroraWright/Luma3DS/blob/master/sysmodules/loader/source/memory.c:35. */
+uint8_t *search_pattern(void *_mem, size_t mem_size, const void *_pattern, size_t pattern_size) {
+    const uint8_t *pattern = (const uint8_t *)_pattern;
+    uint8_t *mem = (uint8_t *)_mem;
+    
+    uint32_t table[0x100];
+    for (unsigned int i = 0; i < sizeof(table)/sizeof(uint32_t); i++) {
+        table[i] = (uint32_t)pattern_size;
+    }
+    for (unsigned int i = 0; i < pattern_size - 1; i++) {
+        table[pattern[i]] = (uint32_t)pattern_size - i - 1;
+    }
+    
+    for (unsigned int i = 0; i <= mem_size - pattern_size; i += table[mem[i + pattern_size - 1]]) {
+        if (pattern[pattern_size - 1] == mem[i + pattern_size - 1] && memcmp(pattern, mem + i, pattern_size - 1) == 0) {
+            return mem + i;
+        }
+    }
+    return NULL;
+}
+
+const kernel_info_t *get_kernel_info(void *kernel, size_t size) {
+    uint32_t kernel_crc32 = crc32c(kernel, size);
+    
+    for (unsigned int i = 0; i < sizeof(g_kernel_infos) / sizeof(kernel_info_t); i++)
+    {
+        if (g_kernel_infos[i].crc32 == kernel_crc32)
+        {
+            return &g_kernel_infos[i];
+        }
+    }
+    return NULL;
+}
+
+void package2_patch_kernel(gfx_con_t* gfx_con, void *_kernel, size_t size) {
+    const kernel_info_t *kernel_info = get_kernel_info(_kernel, size);
+    if (kernel_info == NULL) {
+        gfx_printf(gfx_con, "kernel_patcher: unable to identify kernel!\n");
+    }
+
+    /* Apply hooks. */
+    uint8_t *kernel = (uint8_t *)_kernel;
+    size_t free_space_offset = kernel_info->free_code_space_offset;
+    size_t free_space_size = ((free_space_offset + 0xFFFULL) & ~0xFFFULL) - free_space_offset;
+    bool bPatched = false;
+    for (unsigned int i = 0; i < kernel_info->num_hooks; i++) {
+        size_t hook_size = sizeof(instruction_t) * kernel_info->hooks[i].payload_num_instructions;
+        if (kernel_info->hooks[i].branch_back_offset) {
+            hook_size += sizeof(instruction_t);
+        }
+        if (free_space_size < hook_size) {
+            /* TODO: What should be done in this case? */
+            gfx_printf(gfx_con, "kernel_patcher: insufficient space to apply patches!\n");
+            wait_for_button_and_reboot();
+        }
+        
+        uint8_t *pattern_loc = search_pattern(kernel, size, kernel_info->hooks[i].pattern, kernel_info->hooks[i].pattern_size);
+        if (pattern_loc == NULL) {
+            gfx_printf(gfx_con, "Unable to find pattern %d...\n", i);
+
+            /* TODO: Should we print an error/abort here? */
+            continue;
+        }
+        /* Patch kernel to branch to our hook at the desired place. */
+        instruction_t *hook_start = (instruction_t *)(pattern_loc + kernel_info->hooks[i].pattern_hook_offset);
+        *hook_start = MAKE_BRANCH((uint32_t)((uintptr_t)hook_start - (uintptr_t)kernel), free_space_offset);
+        
+        /* Insert hook into free space. */
+        instruction_t *payload = (instruction_t *)(kernel + free_space_offset);
+        for (unsigned int p = 0; p < kernel_info->hooks[i].payload_num_instructions; p++) {
+            payload[p] = kernel_info->hooks[i].payload[p];
+        }
+        if (kernel_info->hooks[i].branch_back_offset) {
+            payload[kernel_info->hooks[i].payload_num_instructions] = MAKE_BRANCH(free_space_offset + sizeof(instruction_t) * kernel_info->hooks[i].payload_num_instructions, (uint32_t)(kernel_info->hooks[i].branch_back_offset + (uintptr_t)hook_start - (uintptr_t)kernel));
+        }
+        
+        free_space_offset += hook_size;
+        free_space_size -= hook_size;
+
+        bPatched = true;
+    }
+
+    // If we applied no patches, then panic
+    if (!bPatched) {
+        gfx_printf(gfx_con, "Unable to patch kernel!\n");
+        wait_for_button_and_reboot();
+    }
+}

--- a/ipl/fusee_kernel_patches.c
+++ b/ipl/fusee_kernel_patches.c
@@ -1,3 +1,4 @@
+// Fusee kernel_patches.c taken from https://github.com/Atmosphere-NX/Atmosphere/blob/master/fusee/fusee-secondary/src/kernel_patches.c
 #include <string.h>
 #include <stdbool.h>
 #include "fusee_kernel_patches.h"

--- a/ipl/fusee_kernel_patches.h
+++ b/ipl/fusee_kernel_patches.h
@@ -1,0 +1,8 @@
+#ifndef FUSEE_KERNEL_PATCHES_H
+#define FUSEE_KERNEL_PATCHES_H
+
+#include "gfx.h"
+
+void package2_patch_kernel(gfx_con_t* gfx_con, void *kernel, size_t kernel_size);
+
+#endif

--- a/ipl/hos.c
+++ b/ipl/hos.c
@@ -33,6 +33,8 @@
 #include "ff.h"
 #include "di.h"
 
+#include "fusee_kernel_patches.h"
+
 #include "gfx.h"
 extern gfx_ctxt_t gfx_ctxt;
 extern gfx_con_t gfx_con;
@@ -61,6 +63,8 @@ typedef struct _launch_ctxt_t
 
 	int svcperm;
 	int debugmode;
+
+	int fuseepatch;
 } launch_ctxt_t;
 
 typedef struct _merge_kip_t
@@ -344,6 +348,16 @@ static int _config_debugmode(launch_ctxt_t *ctxt, const char *value)
 	return 1;
 }
 
+static int _config_fuseepatch(launch_ctxt_t *ctxt, const char *value)
+{
+	if (*value == '1')
+	{
+		DPRINTF("Enabled Fusee patches\n");
+		ctxt->fuseepatch = 1;
+	}
+	return 1;
+}
+
 typedef struct _cfg_handler_t
 {
 	const char *key;
@@ -357,6 +371,7 @@ static const cfg_handler_t _config_handlers[] = {
 	{ "kip1", _config_kip1 },
 	{ "fullsvcperm", _config_svcperm },
 	{ "debugmode", _config_debugmode },
+	{ "fuseepatch", _config_fuseepatch },
 	{ NULL, NULL },
 };
 
@@ -464,6 +479,12 @@ int hos_launch(ini_sec_t *cfg)
 				if (ctxt.debugmode && kernel_patchset[1].off != 0xFFFFFFFF)
 					*(vu32 *)(ctxt.kernel + kernel_patchset[1].off) = kernel_patchset[1].val;
 			}
+		}
+
+		if (ctxt.fuseepatch)
+		{
+			// Patch the kernel with the fusee patches
+			package2_patch_kernel(&gfx_con, ctxt.kernel, ctxt.kernel_size);
 		}
 	}
 


### PR DESCRIPTION
There are a few changes to the base fusee patches file to get things to work right:
- Fixed the MAKE_* defines
- Used crc32 for kernel matching, so I didn't need fusee's se.c module
- Don't include the proc_id_send patch, as it broke LayeredFS
- Include a custom wait_for_button_and_reboot method
- Fix an error in search_pattern()
- Use gfx_printf for debug output
- Panic if no kernel patch was applied

The application of this patch is configured in hekate_ipl.ini, using a new "fuseepatch" option.

I've included the 5.X and 4.X patches from the latest Fusee master.