### PR TITLE
fix archive bit on all files except official Nintendo directory

### DIFF
--- a/ipl/main.c
+++ b/ipl/main.c
@@ -1910,8 +1910,8 @@ int fix_attributes(char *path, u32 *total, u32 is_root, u32 check_first_run)
 {
 	FRESULT res;
 	DIR dir;
-	u32 i = 0;
-	u32 k = 0;
+	u32 dirLength = 0;
+	u32 fileLength = 0;
 	static FILINFO fno;
 
 	if (check_first_run)
@@ -1942,20 +1942,20 @@ int fix_attributes(char *path, u32 *total, u32 is_root, u32 check_first_run)
 
 			if (is_root && !strcmp(fno.fname, "Nintendo"))
 			{
-				path[i] = 0;
+				path[dirLength] = 0;
 				continue;
 			}
 
 			// Set new directory.
-			i = strlen(path);
-			memcpy(&path[i], "/", 1);
-			for (k = 0; k < 256; k++)
+			dirLength = strlen(path);
+			memcpy(&path[dirLength], "/", 1);
+			for (fileLength = 0; fileLength < 256; fileLength++)
 			{
-				if (fno.fname[k] == 0)
+				if (fno.fname[fileLength] == 0)
 					break;
 			}
-			memcpy(&path[i+1], fno.fname, k + 1);
-			path[i + k + 2] = 0;
+			memcpy(&path[dirLength+1], fno.fname, fileLength + 1);
+			path[dirLength + fileLength + 2] = 0;
 
 			// Check if archive bit is set.
 			if (fno.fattrib & AM_ARC)
@@ -1973,7 +1973,7 @@ int fix_attributes(char *path, u32 *total, u32 is_root, u32 check_first_run)
 					break;
 			}
 			// Clear file or folder path.
-			path[i] = 0;
+			path[dirLength] = 0;
 		}
 		f_closedir(&dir);
 	}

--- a/ipl/main.c
+++ b/ipl/main.c
@@ -1906,7 +1906,7 @@ out:;
 	btn_wait();
 }
 
-int fix_attributes(char *path, u32 *total)
+int fix_attributes(char *path, u32 *total, u32 is_root, u32 check_first_run)
 {
 	FRESULT res;
 	DIR dir;
@@ -1914,9 +1914,20 @@ int fix_attributes(char *path, u32 *total)
 	u32 k = 0;
 	static FILINFO fno;
 
-	// Remove archive bit for selected "root" path.
-	f_chmod(path, 0, AM_ARC);
+	if (check_first_run)
+	{
+		res = f_stat(path, &fno);
+		if (res != FR_OK)
+			return res;
 
+		// Check if archive bit is set.
+		if (fno.fattrib & AM_ARC)
+		{
+			*(u32 *)total = *(u32 *)total + 1;
+			f_chmod(path, 0, AM_ARC);
+		}
+	}
+	
 	// Open directory.
 	res = f_opendir(&dir, path);
 	if (res == FR_OK)
@@ -1928,6 +1939,12 @@ int fix_attributes(char *path, u32 *total)
 			// Break on error or end of dir.
 			if (res != FR_OK || fno.fname[0] == 0)
 				break;
+
+			if (is_root && !strcmp(fno.fname, "Nintendo"))
+			{
+				path[i] = 0;
+				continue;
+			}
 
 			// Set new directory.
 			i = strlen(path);
@@ -1951,7 +1968,7 @@ int fix_attributes(char *path, u32 *total)
 			if (fno.fattrib & AM_DIR)
 			{
 				// Enter the directory.
-				res = fix_attributes(path, total);
+				res = fix_attributes(path, total, 0, 0);
 				if (res != FR_OK)
 					break;
 			}
@@ -1969,7 +1986,8 @@ void fix_sd_attr(u32 type)
 	gfx_clear_grey(&gfx_ctxt, 0x1B);
 	gfx_con_setpos(&gfx_con, 0, 0);
 
-	char buff[256];
+	char path[256];
+	char label[14];
 
 	u32 total = 0;
 	if (sd_mount())
@@ -1977,25 +1995,26 @@ void fix_sd_attr(u32 type)
 		switch (type)
 		{
 		case 0:
-			gfx_printf(&gfx_con, "Traversing all switch folder files!\nThis may take some time, please wait...\n");
-			memcpy(buff, "/switch\0", 8);
+			memcpy(path, "/", 2);
+			memcpy(label, "sd card", 8);
 			break;
 		case 1:
 		default:
-			gfx_printf(&gfx_con, "Traversing all sd card files!\nThis may take some time, please wait...\n");
-			memcpy(buff, "/\0", 2);
+			memcpy(path, "/switch", 8);
+			memcpy(label, "switch folder", 14);
 			break;
 		}
 		
-		fix_attributes(buff, &total);
-		gfx_printf(&gfx_con, "\n%kTotal archive bits cleared: %d!%k\n\nDone! Press any key...", 0xFF96FF00, total, 0xFFCCCCCC);
+		gfx_printf(&gfx_con, "Traversing all %s files!\nThis may take some time, please wait...\n\n", label);
+		fix_attributes(path, &total, !type, type);
+		gfx_printf(&gfx_con, "%kTotal archive bits cleared: %d!%k\n\nDone! Press any key...", 0xFF96FF00, total, 0xFFCCCCCC);
 		sd_unmount();
 	}
 	btn_wait();
 }
 
-void fix_sd_switch_attr() { fix_sd_attr(0); }
-void fix_sd_all_attr() { fix_sd_attr(1); }
+void fix_sd_all_attr() { fix_sd_attr(0); }
+void fix_sd_switch_attr() { fix_sd_attr(1); }
 
 void print_fuel_gauge_info()
 {
@@ -2431,8 +2450,8 @@ ment_t ment_tools[] = {
 	MDEF_CAPTION("-------- Misc --------", 0xFF0AB9E6),
 	MDEF_HANDLER("Dump package1", dump_package1),
 	MDEF_HANDLER("Fix battery de-sync", fix_battery_desync),
-	MDEF_HANDLER("Remove archive bit (switch folder)", fix_sd_switch_attr),
-	//MDEF_HANDLER("Remove archive bit (all sd files)", fix_sd_all_attr),
+	MDEF_HANDLER("Unset switch archive attributes", fix_sd_switch_attr),
+	MDEF_HANDLER("Unset all archive attributes", fix_sd_all_attr),
 	//MDEF_HANDLER("Fix fuel gauge configuration", fix_fuel_gauge_configuration),
 	//MDEF_HANDLER("Reset all battery cfg", reset_pmic_fuel_gauge_charger_config),
 	MDEF_CHGLINE(),

--- a/ipl/main.c
+++ b/ipl/main.c
@@ -1938,6 +1938,9 @@ int fix_attributes(char *path, u32 *total, u32 is_root, u32 check_first_run)
 	dirLength = strlen(path);
 	for (;;)
 	{
+		// Clear file or folder path.
+		path[dirLength] = 0;
+
 		// Read a directory item.
 		res = f_readdir(&dir, &fno);
 
@@ -1947,10 +1950,7 @@ int fix_attributes(char *path, u32 *total, u32 is_root, u32 check_first_run)
 
 		// Skip official Nintendo dir.
 		if (is_root && !strcmp(fno.fname, "Nintendo"))
-		{
-			path[dirLength] = 0;
 			continue;
-		}
 
 		// Set new directory or file.
 		memcpy(&path[dirLength], "/", 1);
@@ -1972,9 +1972,6 @@ int fix_attributes(char *path, u32 *total, u32 is_root, u32 check_first_run)
 			if (res != FR_OK)
 				break;
 		}
-
-		// Clear file or folder path.
-		path[dirLength] = 0;
 	}
 
 	f_closedir(&dir);

--- a/ipl/main.c
+++ b/ipl/main.c
@@ -1914,8 +1914,10 @@ int fix_attributes(char *path, u32 *total, u32 is_root, u32 check_first_run)
 	u32 fileLength = 0;
 	static FILINFO fno;
 
+	// Should we set the bit of the entry directory?
 	if (check_first_run)
 	{
+		// Read file attributes.
 		res = f_stat(path, &fno);
 		if (res != FR_OK)
 			return res;
@@ -1937,17 +1939,19 @@ int fix_attributes(char *path, u32 *total, u32 is_root, u32 check_first_run)
 		{
 			// Read a directory item.
 			res = f_readdir(&dir, &fno);
+
 			// Break on error or end of dir.
 			if (res != FR_OK || fno.fname[0] == 0)
 				break;
 
+			// Skip official Nintendo dir.
 			if (is_root && !strcmp(fno.fname, "Nintendo"))
 			{
 				path[dirLength] = 0;
 				continue;
 			}
 
-			// Set new directory.
+			// Set new directory or file.
 			memcpy(&path[dirLength], "/", 1);
 			fileLength = strlen(fno.fname);
 			memcpy(&path[dirLength+1], fno.fname, fileLength + 1);
@@ -1967,9 +1971,11 @@ int fix_attributes(char *path, u32 *total, u32 is_root, u32 check_first_run)
 				if (res != FR_OK)
 					break;
 			}
+
 			// Clear file or folder path.
 			path[dirLength] = 0;
 		}
+
 		f_closedir(&dir);
 	}
 

--- a/ipl/main.c
+++ b/ipl/main.c
@@ -1911,7 +1911,6 @@ int fix_attributes(char *path, u32 *total, u32 is_root, u32 check_first_run)
 	FRESULT res;
 	DIR dir;
 	u32 dirLength = 0;
-	u32 fileLength = 0;
 	static FILINFO fno;
 
 	// Should we set the bit of the entry directory?
@@ -1954,8 +1953,7 @@ int fix_attributes(char *path, u32 *total, u32 is_root, u32 check_first_run)
 
 		// Set new directory or file.
 		memcpy(&path[dirLength], "/", 1);
-		fileLength = strlen(fno.fname);
-		memcpy(&path[dirLength+1], fno.fname, fileLength + 1);
+		memcpy(&path[dirLength+1], fno.fname, strlen(fno.fname) + 1);
 
 		// Check if archive bit is set.
 		if (fno.fattrib & AM_ARC)

--- a/ipl/main.c
+++ b/ipl/main.c
@@ -1951,7 +1951,6 @@ int fix_attributes(char *path, u32 *total, u32 is_root, u32 check_first_run)
 			memcpy(&path[dirLength], "/", 1);
 			fileLength = strlen(fno.fname);
 			memcpy(&path[dirLength+1], fno.fname, fileLength + 1);
-			path[dirLength + fileLength + 2] = 0;
 
 			// Check if archive bit is set.
 			if (fno.fattrib & AM_ARC)

--- a/ipl/main.c
+++ b/ipl/main.c
@@ -1932,6 +1932,7 @@ int fix_attributes(char *path, u32 *total, u32 is_root, u32 check_first_run)
 	res = f_opendir(&dir, path);
 	if (res == FR_OK)
 	{
+		dirLength = strlen(path);
 		for (;;)
 		{
 			// Read a directory item.
@@ -1947,7 +1948,6 @@ int fix_attributes(char *path, u32 *total, u32 is_root, u32 check_first_run)
 			}
 
 			// Set new directory.
-			dirLength = strlen(path);
 			memcpy(&path[dirLength], "/", 1);
 			for (fileLength = 0; fileLength < 256; fileLength++)
 			{

--- a/ipl/main.c
+++ b/ipl/main.c
@@ -1949,11 +1949,7 @@ int fix_attributes(char *path, u32 *total, u32 is_root, u32 check_first_run)
 
 			// Set new directory.
 			memcpy(&path[dirLength], "/", 1);
-			for (fileLength = 0; fileLength < 256; fileLength++)
-			{
-				if (fno.fname[fileLength] == 0)
-					break;
-			}
+			fileLength = strlen(fno.fname);
 			memcpy(&path[dirLength+1], fno.fname, fileLength + 1);
 			path[dirLength + fileLength + 2] = 0;
 


### PR DESCRIPTION
When I ran the fix archive bit on only the `/switch` directory, I was seeing other directories being shown as a 0-byte file in `ftpd` and `nx-shell` homebrew apps. After reproducing it multiple times, I figured I'd take a stab at fixing it myself. After running my updated archive bit removal script on all files in the SD, with the logic of skipping the official Nintendo directory, I can now see all folders coming through correctly in those apps, and the official Nintendo apps all load correctly.