### PR TITLE
Allow dumping TSEC keys to sd card

### DIFF
--- a/ipl/main.c
+++ b/ipl/main.c
@@ -665,31 +665,52 @@ void print_tsec_key()
 	{
 		EPRINTFARGS("Could not identify package1 version\nto read TSEC firmware (= '%s').",
 			(char *)pkg1 + 0x10);
+		
+		gfx_puts(&gfx_con, "\nPress any key...\n");
+		btn_wait();
 		goto out;
 	}
 
+	u8 keys[0x10 * 3];
 	for(u32 i = 1; i <= 3; i++)
 	{
-		u8 key[0x10];
-		int res = tsec_query(key, i, pkg1 + pkg1_id->tsec_off);
+		int res = tsec_query(keys + ((i - 1) * 0x10), i, pkg1 + pkg1_id->tsec_off);
 
 		gfx_printf(&gfx_con, "%kTSEC key %d: %k", 0xFF00DDFF, i, 0xFFCCCCCC);
 		if (res >= 0)
 		{
-			for (u32 i = 0; i < 0x10; i++)
-				gfx_printf(&gfx_con, "%02X", key[i]);
+			for (u32 j = 0; j < 0x10; j++)
+				gfx_printf(&gfx_con, "%02X", keys[((i - 1) * 0x10) + j]);
 		}
 		else
 			EPRINTFARGS("ERROR %X", res);
 		gfx_putc(&gfx_con, '\n');
 	}
+	
+		free(pkg1);
+	sdmmc_storage_end(&storage);
+
+	gfx_puts(&gfx_con, "\nPress POWER to dump them to SD Card.\nPress VOL to go to the menu.\n");
+	
+	u32 btn = btn_wait();
+	if (btn & BTN_POWER)
+	{
+		if (sd_mount())
+		{
+			char tsec_keyFilename[26];
+			f_mkdir("Backup");
+			f_mkdir("Backup/Dumps");
+			memcpy(tsec_keyFilename, "Backup/Dumps/tsec_key.bin", 26);
+
+			if (!sd_save_to_file(keys, 0x10 * 3, tsec_keyFilename))
+				gfx_puts(&gfx_con, "\nDone!\n");
+			sd_unmount();
+		}
+	}
 
 out:;
 	free(pkg1);
 	sdmmc_storage_end(&storage);
-
-	gfx_puts(&gfx_con, "\nPress any key...\n");
-	btn_wait();
 }
 
 void reboot_normal()

--- a/ipl/main.c
+++ b/ipl/main.c
@@ -660,16 +660,15 @@ void print_tsec_key()
 	u8 *pkg1 = (u8 *)malloc(0x40000);
 	sdmmc_storage_set_mmc_partition(&storage, 1);
 	sdmmc_storage_read(&storage, 0x100000 / NX_EMMC_BLOCKSIZE, 0x40000 / NX_EMMC_BLOCKSIZE, pkg1);
+	sdmmc_storage_end(&storage);
 	const pkg1_id_t *pkg1_id = pkg1_identify(pkg1);
 	if (!pkg1_id)
 	{
 		EPRINTFARGS("Could not identify package1 version\nto read TSEC firmware (= '%s').",
 			(char *)pkg1 + 0x10);
-		
-		gfx_puts(&gfx_con, "\nPress any key...\n");
-		btn_wait();
-		goto out;
+		goto out_wait;
 	}
+	
 
 	u8 keys[0x10 * 3];
 	for(u32 i = 1; i <= 3; i++)
@@ -686,9 +685,6 @@ void print_tsec_key()
 			EPRINTFARGS("ERROR %X", res);
 		gfx_putc(&gfx_con, '\n');
 	}
-	
-		free(pkg1);
-	sdmmc_storage_end(&storage);
 
 	gfx_puts(&gfx_con, "\nPress POWER to dump them to SD Card.\nPress VOL to go to the menu.\n");
 	
@@ -707,10 +703,16 @@ void print_tsec_key()
 			sd_unmount();
 		}
 	}
-
+	else
+	{
+		goto out;
+	}
+	
+out_wait:;
+	btn_wait();
+	
 out:;
 	free(pkg1);
-	sdmmc_storage_end(&storage);
 }
 
 void reboot_normal()


### PR DESCRIPTION
It would be useful if we could dump the TSEC keys just like the fuses and kfuses