### PR TITLE
just use normal arm-none-eabi toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,4 @@
-ifeq ($(strip $(DEVKITARM)),)
-$(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>devkitARM")
-endif
-
-include $(DEVKITARM)/base_rules
+include rules/dkarm_compat
 
 TARGET := hekate
 BLVERSION_MAJOR := 4
@@ -54,11 +50,11 @@ OBJS += $(addprefix $(BUILD)/$(TARGET)/, \
 	elfload.o elfreloc_arm.o \
 )
 
-ARCH := -march=armv4t -mtune=arm7tdmi -mthumb -mthumb-interwork
-CUSTOMDEFINES := -DBLVERSIONMJ=$(BLVERSION_MAJOR) -DBLVERSIONMN=$(BLVERSION_MINOR)
-CUSTOMDEFINES += -DMENU_LOGO_ENABLE #-DDEBUG
-CFLAGS = $(ARCH) -O2 -nostdlib -ffunction-sections -fdata-sections -fomit-frame-pointer -fno-inline -std=gnu11 -Wall $(CUSTOMDEFINES)
-LDFLAGS = $(ARCH) -nostartfiles -lgcc -Wl,--nmagic,--gc-sections
+CFLAGS += -mthumb
+LDFLAGS += -mthumb
+CFLAGS += -DBLVERSIONMJ=$(BLVERSION_MAJOR) -DBLVERSIONMN=$(BLVERSION_MINOR)
+CFLAGS += -DMENU_LOGO_ENABLE
+#CFLAGS += -DDEBUG
 
 MODULEDIRS := $(wildcard modules/*)
 

--- a/bootloader/hos/pkg2.c
+++ b/bootloader/hos/pkg2.c
@@ -752,7 +752,7 @@ const char* pkg2_patch_kips(link_t *info, char* patchNames)
 			if (!se_calc_sha256(shaBuf, ki->kip1, ki->size))
 				memset(shaBuf, 0, sizeof(shaBuf));
 
-			DPRINTF("%dms %s KIP1 size %d hash %08X\n", (postDecompTime-preDecompTime)/1000, ki->kip1->name, (int)ki->size, __builtin_bswap32(shaBuf[0]));
+			DPRINTF("%dms %s KIP1 size %d hash %08X\n", (postDecompTime-preDecompTime)/1000, ki->kip1->name, (int)ki->size, byte_swap_32(shaBuf[0]));
 #endif
 
 			currPatchset = _kip_ids[currKipIdx].patchset;
@@ -852,6 +852,7 @@ DPRINTF("sec %d has size %08X\n", i, hdr->sec_size[i]);
 void pkg2_build_encrypt(void *dst, void *kernel, u32 kernel_size, link_t *kips_info)
 {
 	u8 *pdst = (u8 *)dst;
+	u32 ctr;
 
 	// Signature.
 	memset(pdst, 0, 0x100);
@@ -894,9 +895,10 @@ DPRINTF("adding kip1 '%s' @ %08X (%08X)\n", ki->kip1->name, (u32)ki->kip1, ki->s
 DPRINTF("INI1 encrypted\n");
 
 	//Encrypt header.
-	*(u32 *)hdr->ctr = 0x100 + sizeof(pkg2_hdr_t) + kernel_size + ini1_size;
+	ctr = 0x100 + sizeof(pkg2_hdr_t) + kernel_size + ini1_size;
+	memcpy(hdr->ctr, &ctr, sizeof(ctr));
 	se_aes_crypt_ctr(8, hdr, sizeof(pkg2_hdr_t), hdr, sizeof(pkg2_hdr_t), hdr);
 	memset(hdr->ctr, 0 , 0x10);
-	*(u32 *)hdr->ctr = 0x100 + sizeof(pkg2_hdr_t) + kernel_size + ini1_size;
+	memcpy(hdr->ctr, &ctr, sizeof(ctr));
 }
 

--- a/bootloader/soc/clock.c
+++ b/bootloader/soc/clock.c
@@ -19,7 +19,7 @@
 #include "../utils/util.h"
 #include "../storage/sdmmc.h"
 
-static const clock_t _clock_uart[] = {
+static const clk_desc_t _clock_uart[] = {
 	/* UART A */ { CLK_RST_CONTROLLER_RST_DEVICES_L, CLK_RST_CONTROLLER_CLK_OUT_ENB_L, CLK_RST_CONTROLLER_CLK_SOURCE_UARTA, 6, 0, 0 },
 	/* UART B */ { CLK_RST_CONTROLLER_RST_DEVICES_L, CLK_RST_CONTROLLER_CLK_OUT_ENB_L, CLK_RST_CONTROLLER_CLK_SOURCE_UARTB, 7, 0, 0 },
 	/* UART C */ { CLK_RST_CONTROLLER_RST_DEVICES_H, CLK_RST_CONTROLLER_CLK_OUT_ENB_H, CLK_RST_CONTROLLER_CLK_SOURCE_UARTC, 0x17, 0, 0 },
@@ -27,7 +27,7 @@ static const clock_t _clock_uart[] = {
 	/* UART E */ { 0 }
 };
 
-static const clock_t _clock_i2c[] = {
+static const clk_desc_t _clock_i2c[] = {
 	/* I2C1 */ { CLK_RST_CONTROLLER_RST_DEVICES_L, CLK_RST_CONTROLLER_CLK_OUT_ENB_L, CLK_RST_CONTROLLER_CLK_SOURCE_I2C1, 0xC, 6, 0 },
 	/* I2C2 */ { 0 },
 	/* I2C3 */ { 0 },
@@ -36,22 +36,22 @@ static const clock_t _clock_i2c[] = {
 	/* I2C6 */ { 0 }
 };
 
-static clock_t _clock_se = { CLK_RST_CONTROLLER_RST_DEVICES_V, CLK_RST_CONTROLLER_CLK_OUT_ENB_V, CLK_RST_CONTROLLER_CLK_SOURCE_SE, 0x1F, 0, 0 };
-static clock_t _clock_unk2 = { CLK_RST_CONTROLLER_RST_DEVICES_V, CLK_RST_CONTROLLER_CLK_OUT_ENB_V, CLK_RST_CONTROLLER_RST_SOURCE, 0x1E, 0, 0 };
+static clk_desc_t _clock_se = { CLK_RST_CONTROLLER_RST_DEVICES_V, CLK_RST_CONTROLLER_CLK_OUT_ENB_V, CLK_RST_CONTROLLER_CLK_SOURCE_SE, 0x1F, 0, 0 };
+static clk_desc_t _clock_unk2 = { CLK_RST_CONTROLLER_RST_DEVICES_V, CLK_RST_CONTROLLER_CLK_OUT_ENB_V, CLK_RST_CONTROLLER_RST_SOURCE, 0x1E, 0, 0 };
 
-static clock_t _clock_host1x = { CLK_RST_CONTROLLER_RST_DEVICES_L, CLK_RST_CONTROLLER_CLK_OUT_ENB_L, CLK_RST_CONTROLLER_CLK_SOURCE_HOST1X, 0x1C, 4, 3 };
-static clock_t _clock_tsec = { CLK_RST_CONTROLLER_RST_DEVICES_U, CLK_RST_CONTROLLER_CLK_OUT_ENB_U, CLK_RST_CONTROLLER_CLK_SOURCE_TSEC, 0x13, 0, 2 };
-static clock_t _clock_sor_safe = { CLK_RST_CONTROLLER_RST_DEVICES_Y, CLK_RST_CONTROLLER_CLK_OUT_ENB_Y, CLK_RST_CONTROLLER_RST_SOURCE, 0x1E, 0, 0 };
-static clock_t _clock_sor0 = { CLK_RST_CONTROLLER_RST_DEVICES_X, CLK_RST_CONTROLLER_CLK_OUT_ENB_X, CLK_RST_CONTROLLER_RST_SOURCE, 0x16, 0, 0 };
-static clock_t _clock_sor1 = { CLK_RST_CONTROLLER_RST_DEVICES_X, CLK_RST_CONTROLLER_CLK_OUT_ENB_X, CLK_RST_CONTROLLER_CLK_SOURCE_SOR1, 0x17, 0, 2 };
-static clock_t _clock_kfuse = { CLK_RST_CONTROLLER_RST_DEVICES_H, CLK_RST_CONTROLLER_CLK_OUT_ENB_H, CLK_RST_CONTROLLER_RST_SOURCE, 8, 0, 0 };
+static clk_desc_t _clock_host1x = { CLK_RST_CONTROLLER_RST_DEVICES_L, CLK_RST_CONTROLLER_CLK_OUT_ENB_L, CLK_RST_CONTROLLER_CLK_SOURCE_HOST1X, 0x1C, 4, 3 };
+static clk_desc_t _clk_desc_tsec = { CLK_RST_CONTROLLER_RST_DEVICES_U, CLK_RST_CONTROLLER_CLK_OUT_ENB_U, CLK_RST_CONTROLLER_CLK_SOURCE_TSEC, 0x13, 0, 2 };
+static clk_desc_t _clock_sor_safe = { CLK_RST_CONTROLLER_RST_DEVICES_Y, CLK_RST_CONTROLLER_CLK_OUT_ENB_Y, CLK_RST_CONTROLLER_RST_SOURCE, 0x1E, 0, 0 };
+static clk_desc_t _clock_sor0 = { CLK_RST_CONTROLLER_RST_DEVICES_X, CLK_RST_CONTROLLER_CLK_OUT_ENB_X, CLK_RST_CONTROLLER_RST_SOURCE, 0x16, 0, 0 };
+static clk_desc_t _clock_sor1 = { CLK_RST_CONTROLLER_RST_DEVICES_X, CLK_RST_CONTROLLER_CLK_OUT_ENB_X, CLK_RST_CONTROLLER_CLK_SOURCE_SOR1, 0x17, 0, 2 };
+static clk_desc_t _clock_kfuse = { CLK_RST_CONTROLLER_RST_DEVICES_H, CLK_RST_CONTROLLER_CLK_OUT_ENB_H, CLK_RST_CONTROLLER_RST_SOURCE, 8, 0, 0 };
 
-static clock_t _clock_cl_dvfs = { CLK_RST_CONTROLLER_RST_DEVICES_W, CLK_RST_CONTROLLER_CLK_OUT_ENB_W, CLK_RST_CONTROLLER_RST_SOURCE, 0x1B, 0, 0 };
-static clock_t _clock_coresight = { CLK_RST_CONTROLLER_RST_DEVICES_U, CLK_RST_CONTROLLER_CLK_OUT_ENB_U, CLK_RST_CONTROLLER_CLK_SOURCE_CSITE, 9, 0, 4};
+static clk_desc_t _clock_cl_dvfs = { CLK_RST_CONTROLLER_RST_DEVICES_W, CLK_RST_CONTROLLER_CLK_OUT_ENB_W, CLK_RST_CONTROLLER_RST_SOURCE, 0x1B, 0, 0 };
+static clk_desc_t _clock_coresight = { CLK_RST_CONTROLLER_RST_DEVICES_U, CLK_RST_CONTROLLER_CLK_OUT_ENB_U, CLK_RST_CONTROLLER_CLK_SOURCE_CSITE, 9, 0, 4};
 
-static clock_t _clock_pwm = { CLK_RST_CONTROLLER_RST_DEVICES_L, CLK_RST_CONTROLLER_CLK_OUT_ENB_L, CLK_RST_CONTROLLER_CLK_SOURCE_PWM, 0x11, 6, 4};
+static clk_desc_t _clock_pwm = { CLK_RST_CONTROLLER_RST_DEVICES_L, CLK_RST_CONTROLLER_CLK_OUT_ENB_L, CLK_RST_CONTROLLER_CLK_SOURCE_PWM, 0x11, 6, 4};
 
-void clock_enable(const clock_t *clk)
+void clock_enable(const clk_desc_t *clk)
 {
 	// Put clock into reset.
 	CLOCK(clk->reset) = (CLOCK(clk->reset) & ~(1 << clk->index)) | (1 << clk->index);
@@ -66,7 +66,7 @@ void clock_enable(const clock_t *clk)
 	CLOCK(clk->reset) &= ~(1 << clk->index);
 }
 
-void clock_disable(const clock_t *clk)
+void clock_disable(const clk_desc_t *clk)
 {
 	// Put clock into reset.
 	CLOCK(clk->reset) = (CLOCK(clk->reset) & ~(1 << clk->index)) | (1 << clk->index);
@@ -116,12 +116,12 @@ void clock_disable_host1x()
 
 void clock_enable_tsec()
 {
-	clock_enable(&_clock_tsec);
+	clock_enable(&_clk_desc_tsec);
 }
 
 void clock_disable_tsec()
 {
-	clock_disable(&_clock_tsec);
+	clock_disable(&_clk_desc_tsec);
 }
 
 void clock_enable_sor_safe()

--- a/bootloader/soc/clock.h
+++ b/bootloader/soc/clock.h
@@ -117,7 +117,7 @@
 #define CLK_RST_CONTROLLER_SE_SUPER_CLK_DIVIDER 0x704
 
 /*! Generic clock descriptor. */
-typedef struct _clock_t
+typedef struct _clk_desc_t
 {
 	u32 reset;
 	u32 enable;
@@ -125,11 +125,11 @@ typedef struct _clock_t
 	u8 index;
 	u8 clk_src;
 	u8 clk_div;
-} clock_t;
+} clk_desc_t;
 
 /*! Generic clock enable/disable. */
-void clock_enable(const clock_t *clk);
-void clock_disable(const clock_t *clk);
+void clock_enable(const clk_desc_t *clk);
+void clock_disable(const clk_desc_t *clk);
 
 /*! Clock control for specific hardware portions. */
 void clock_enable_fuse(bool enable);

--- a/bootloader/storage/sdmmc.h
+++ b/bootloader/storage/sdmmc.h
@@ -93,8 +93,8 @@ typedef struct _sdmmc_storage_t
 	u32 partition;
 	u8  raw_cid[0x10];
 	u8  raw_csd[0x10];
-	u8  raw_scr[8];
-	u8  raw_ssr[0x40];
+	u32 raw_scr[2];
+	u32 raw_ssr[16];
 	mmc_cid_t     cid;
 	mmc_csd_t     csd;
 	mmc_ext_csd_t ext_csd;

--- a/bootloader/utils/util.c
+++ b/bootloader/utils/util.c
@@ -96,3 +96,34 @@ u32 memcmp32sparse(const u32 *buf1, const u32 *buf2, u32 len)
 
 	return 0;
 }
+
+char *itoa(int value, char *str, int base)
+{
+	char *p = str;
+	const char lut[] = "0123456789abcdef";
+	bool negative = false;
+
+	if (base < 2 || base > 16)
+	{
+		*p = '\0';
+		return str;
+	}
+
+	if (value < 0)
+	{
+		value = -value;
+		negative = true;
+	}
+
+	if (negative)
+		p++;
+	for (int v = value; v; v /= base)
+		p++;
+	*p-- = '\0';
+	for (int v = value; v; v /= base)
+		*p-- = lut[v % base];
+	if (negative)
+		*p-- = '-';
+
+	return str;
+}

--- a/bootloader/utils/util.h
+++ b/bootloader/utils/util.h
@@ -20,8 +20,7 @@
 
 #include "types.h"
 
-#define byte_swap_32(num) ((num >> 24) & 0xff) | ((num << 8) & 0xff0000) | \
-						((num >> 8 )& 0xff00) | ((num << 24) & 0xff000000)
+#define byte_swap_32(val) __builtin_bswap32(val)
 
 typedef struct _cfg_op_t
 {
@@ -40,5 +39,7 @@ u32 crc32c(const void *buf, u32 len);
 /* This is a faster implementation of memcmp that checks two u32 values */
 /* every 128 Bytes block. Intented only for Backup and Restore          */
 u32 memcmp32sparse(const u32 *buf1, const u32 *buf2, u32 len);
+
+char *itoa(int value, char *str, int base);
 
 #endif

--- a/modules/hekate_libsys_lp0/Makefile
+++ b/modules/hekate_libsys_lp0/Makefile
@@ -1,8 +1,4 @@
-ifeq ($(strip $(DEVKITARM)),)
-$(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>devkitARM")
-endif
-
-include $(DEVKITARM)/base_rules
+include ../../rules/dkarm_compat
 
 TARGET := libsys_lp0
 BUILD := ../../build/$(TARGET)
@@ -13,19 +9,15 @@ OBJS = $(addprefix $(BUILD)/,\
 	sys_sdramlp0.o \
 )
 
-ARCH := -march=armv4t -mtune=arm7tdmi -mthumb-interwork
-CFLAGS = $(ARCH) -O2 -nostdlib -fpie -ffunction-sections -fdata-sections -fomit-frame-pointer -fno-inline -std=gnu11 -Wall $(CUSTOMDEFINES)
-LDFLAGS = $(ARCH) -fpie -pie -nostartfiles -lgcc
-
 .PHONY: clean all
 
 all: $(TARGET).bso
 $(BUILD)/%.o: ./%.c
 	@mkdir -p "$(BUILD)"
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(SO_CFLAGS) -c $< -o $@
 	
 $(TARGET).bso: $(OBJS)
-	$(CC) $(LDFLAGS) -e _modInit $^ -o $(OUTPUT)/$(TARGET).bso
+	$(CC) $(SO_LDFLAGS) -e _modInit $^ -o $(OUTPUT)/$(TARGET).bso
 	$(STRIP) -g $(OUTPUT)/$(TARGET).bso
 
 clean:

--- a/modules/simple_sample/Makefile
+++ b/modules/simple_sample/Makefile
@@ -1,8 +1,4 @@
-ifeq ($(strip $(DEVKITARM)),)
-$(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>devkitARM")
-endif
-
-include $(DEVKITARM)/base_rules
+include ../../rules/dkarm_compat
 
 TARGET := module_sample
 BUILD := ../../build/$(TARGET)
@@ -14,19 +10,15 @@ OBJS = $(addprefix $(BUILD)/,\
 	gfx.o \
 )
 
-ARCH := -march=armv4t -mtune=arm7tdmi -mthumb-interwork
-CFLAGS = $(ARCH) -O2 -nostdlib -fpie -ffunction-sections -fdata-sections -fomit-frame-pointer -fno-inline -std=gnu11 -Wall $(CUSTOMDEFINES)
-LDFLAGS = $(ARCH) -fpie -pie -nostartfiles -lgcc
-
 .PHONY: clean all
 
 all: $(TARGET).bso
 $(BUILD)/%.o: ./%.c
 	@mkdir -p "$(BUILD)"
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(SO_CFLAGS) -c $< -o $@
 	
 $(TARGET).bso: $(OBJS)
-	$(CC) $(LDFLAGS) -e _modInit $^ -o $(OUTPUT)/$(TARGET).bso
+	$(CC) $(SO_LDFLAGS) -e _modInit $^ -o $(OUTPUT)/$(TARGET).bso
 	$(STRIP) -g $(OUTPUT)/$(TARGET).bso
 
 clean:

--- a/rules/dkarm_compat
+++ b/rules/dkarm_compat
@@ -17,7 +17,7 @@ export RANLIB	:=	$(PREFIX)gcc-ranlib
 endif
 
 ARCH := -march=armv4t -mtune=arm7tdmi -mthumb-interwork
-CFLAGS = $(ARCH) -Os -ffunction-sections -fdata-sections -fomit-frame-pointer -fno-inline -std=gnu11 -Wall
+CFLAGS = $(ARCH) -Os -flto -ffunction-sections -fdata-sections -fomit-frame-pointer -std=gnu11 -Wall
 LDFLAGS = $(ARCH) -nostartfiles -Wl,--nmagic,--gc-sections
 
 SO_CFLAGS = $(CFLAGS) -fpie -marm

--- a/rules/dkarm_compat
+++ b/rules/dkarm_compat
@@ -1,0 +1,24 @@
+ifneq ($(strip $(DEVKITARM)),)
+
+include $(DEVKITARM)/base_rules
+
+else
+
+PREFIX		:=	arm-none-eabi-
+export CC	:=	$(PREFIX)gcc
+export CXX	:=	$(PREFIX)g++
+export AS	:=	$(PREFIX)as
+export AR	:=	$(PREFIX)gcc-ar
+export OBJCOPY	:=	$(PREFIX)objcopy
+export STRIP	:=	$(PREFIX)strip
+export NM	:=	$(PREFIX)gcc-nm
+export RANLIB	:=	$(PREFIX)gcc-ranlib
+
+endif
+
+ARCH := -march=armv4t -mtune=arm7tdmi -mthumb-interwork
+CFLAGS = $(ARCH) -Os -ffunction-sections -fdata-sections -fomit-frame-pointer -fno-inline -std=gnu11 -Wall
+LDFLAGS = $(ARCH) -nostartfiles -Wl,--nmagic,--gc-sections
+
+SO_CFLAGS = $(CFLAGS) -fpie -marm
+SO_LDFLAGS = $(LDFLAGS) -fpie -pie -marm


### PR DESCRIPTION
removes devkitarm as dependency.
devkitarm should still be usable (maybe `itoa` needs to be `weak` tho, idk).