### PR TITLE
Add "Silent" auto full power off option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ There are four possible type of entries. "**[ ]**": Boot entry, "**{ }**": Capti
 | bootwait=3         | 0: Disable (It also disables bootlogo. Having **VOL-** pressed since injection goes to menu.), #: Time to wait for **VOL-** to enter menu. |
 | customlogo=0       | 0: Use default hekate bootlogo, 1: Use bootlogo.bmp.       |
 | verification=2     | 0: Disable Backup/Restore verification, 1: Sparse (block based, fast and not 100% reliable), 2: Full (sha256 based, slow and 100% reliable). |
-| autohosoff=1       | If woke up from HOS via an rtc alarm, power off completely.|
+| autohosoff=1       | 0: Disable, 1: If woke up from HOS via an RTC alarm, shows logo, then powers off completely, 2: No logo, immediately powers off.|
 | backlight=100      | Screen backlight level. 0-255.                             |
 
 

--- a/bootloader/config/config.c
+++ b/bootloader/config/config.c
@@ -645,10 +645,10 @@ void config_auto_hos_poweroff()
 	gfx_clear_grey(&gfx_ctxt, 0x1B);
 	gfx_con_setpos(&gfx_con, 0, 0);
 
-	ment_t *ments = (ment_t *)malloc(sizeof(ment_t) * 5);
-	u32 *hp_values = (u32 *)malloc(sizeof(u32) * 2);
+	ment_t *ments = (ment_t *)malloc(sizeof(ment_t) * 6);
+	u32 *hp_values = (u32 *)malloc(sizeof(u32) * 3);
 
-	for (u32 j = 0; j < 2; j++)
+	for (u32 j = 0; j < 3; j++)
 	{
 		hp_values[j] = j;
 		ments[j + 2].type = MENT_DATA;
@@ -660,19 +660,26 @@ void config_auto_hos_poweroff()
 
 	ments[1].type = MENT_CHGLINE;
 
-	if (h_cfg.autohosoff)
+	if (h_cfg.autohosoff == 1)
 	{
 		ments[2].caption = " Disable";
 		ments[3].caption = "*Enable";
-
+		ments[4].caption = " Enable (No logo)";
+	}
+	else if (h_cfg.autohosoff >= 2)
+	{
+		ments[2].caption = " Disable";
+		ments[3].caption = " Enable";
+		ments[4].caption = "*Enable (No logo)";
 	}
 	else
 	{
 		ments[2].caption = "*Disable";
 		ments[3].caption = " Enable";
+		ments[4].caption = " Enable (No logo)";
 	}
 
-	memset(&ments[4], 0, sizeof(ment_t));
+	memset(&ments[5], 0, sizeof(ment_t));
 	menu_t menu = {ments, "Power off if woke up from HOS", 0, 0};
 
 	u32 *temp_autohosoff = (u32 *)tui_do_menu(&gfx_con, &menu);

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -260,17 +260,18 @@ void check_power_off_from_hos()
 	if (hosWakeup & MAX77620_IRQ_TOP_RTC_MASK)
 	{
 		sd_unmount();
+		if (h_cfg.autohosoff == 1)
+		{
+			gfx_clear_grey(&gfx_ctxt, 0x1B);
+			u8 *BOOTLOGO = (void *)malloc(0x4000);
+			blz_uncompress_srcdest(BOOTLOGO_BLZ, SZ_BOOTLOGO_BLZ, BOOTLOGO, SZ_BOOTLOGO);
+			gfx_set_rect_grey(&gfx_ctxt, BOOTLOGO, X_BOOTLOGO, Y_BOOTLOGO, 326, 544);
 
-		gfx_clear_grey(&gfx_ctxt, 0x1B);
-		u8 *BOOTLOGO = (void *)malloc(0x4000);
-		blz_uncompress_srcdest(BOOTLOGO_BLZ, SZ_BOOTLOGO_BLZ, BOOTLOGO, SZ_BOOTLOGO);
-		gfx_set_rect_grey(&gfx_ctxt, BOOTLOGO, X_BOOTLOGO, Y_BOOTLOGO, 326, 544);
-
-		display_backlight_brightness(10, 5000);
-		display_backlight_brightness(100, 25000);
-		usleep(600000);
-		display_backlight_brightness(0, 20000);
-
+			display_backlight_brightness(10, 5000);
+			display_backlight_brightness(100, 25000);
+			usleep(600000);
+			display_backlight_brightness(0, 20000);
+		}
 		power_off();
 	}
 }


### PR DESCRIPTION
Adds a third option to the "autohosoff" config setting that disables the "heartbeat" of the Hekate logo before actually turning off, and instead instantly powers down without any notice. This was the behavior I expected from this feature originally, but it does seem ideal to keep the original functionality considering the confusion this feature has caused.