### PR TITLE
Ignore hidden files when using wildcards.

### DIFF
--- a/bootloader/config/ini.c
+++ b/bootloader/config/ini.c
@@ -45,7 +45,7 @@ int ini_parse(link_t *dst, char *ini_path, bool is_dir)
 
 	if (is_dir)
 	{
-		filelist = dirlist(filename, "*.ini");
+		filelist = dirlist(filename, "*.ini", false);
 		if (!filelist)
 		{
 			free(filename);

--- a/bootloader/hos/hos.c
+++ b/bootloader/hos/hos.c
@@ -376,7 +376,7 @@ static int _config_kip1(launch_ctxt_t *ctxt, const char *value)
 
 		u32 dirlen = 0;
 		dir[strlen(dir) - 2] = 0;
-		char *filelist = dirlist(dir, "*.kip*");
+		char *filelist = dirlist(dir, "*.kip*", false);
 
 		memcpy(dir + strlen(dir), "/", 2);
 		dirlen = strlen(dir);

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -1985,7 +1985,7 @@ void launch_tools(u8 type)
 		else
 			memcpy(dir, "bootloader/libtools", 20);
 
-		filelist = dirlist(dir, NULL);
+		filelist = dirlist(dir, NULL, false);
 
 		u32 i = 0;
 

--- a/bootloader/utils/dirlist.c
+++ b/bootloader/utils/dirlist.c
@@ -21,7 +21,7 @@
 #include "../mem/heap.h"
 #include "../utils/types.h"
 
-char *dirlist(const char *directory, const char *pattern)
+char *dirlist(const char *directory, const char *pattern, bool includeHiddenFiles)
 {
 	u8 max_entries = 61;
 
@@ -40,7 +40,7 @@ char *dirlist(const char *directory, const char *pattern)
 			res = f_readdir(&dir, &fno);
 			if (res || !fno.fname[0])
 				break;
-			if (!(fno.fattrib & AM_DIR))
+			if (!(fno.fattrib & AM_DIR) && (fno.fname[0] != '.') && (includeHiddenFiles || !(fno.fattrib & AM_HID)))
 			{
 				memcpy(dir_entries + (k * 256), fno.fname, strlen(fno.fname) + 1);
 				k++;
@@ -54,7 +54,7 @@ char *dirlist(const char *directory, const char *pattern)
 	{
 		do
 		{
-			if (!(fno.fattrib & AM_DIR))
+			if (!(fno.fattrib & AM_DIR) && (fno.fname[0] != '.') && (includeHiddenFiles || !(fno.fattrib & AM_HID)))
 			{
 				memcpy(dir_entries + (k * 256), fno.fname, strlen(fno.fname) + 1);
 				k++;

--- a/bootloader/utils/dirlist.h
+++ b/bootloader/utils/dirlist.h
@@ -16,4 +16,4 @@
 
 #include "../utils/types.h"
 
-char *dirlist(const char *directory, const char *pattern);
+char *dirlist(const char *directory, const char *pattern, bool includeHiddenFiles);


### PR DESCRIPTION
I haven't tested this out yet, but in theory it should work. I had similar code in Switchblade with the splash screens.

(Couldn't be bothered to figure out how to squash commits so I just deleted the repository and forked it again.)