### PR TITLE
heap: Fix calloc memset size

### DIFF
--- a/bootloader/mem/heap.c
+++ b/bootloader/mem/heap.c
@@ -114,7 +114,7 @@ void *malloc(u32 size)
 void *calloc(u32 num, u32 size)
 {
 	void *res = (void *)_heap_alloc(&_heap, num * size, sizeof(hnode_t));
-	memset(res, 0, num * size);
+	memset(res, 0, ALIGN(num * size, sizeof(hnode_t)));
 	return res;
 }
 

--- a/nyx/nyx_gui/mem/heap.c
+++ b/nyx/nyx_gui/mem/heap.c
@@ -114,7 +114,7 @@ void *malloc(u32 size)
 void *calloc(u32 num, u32 size)
 {
 	void *res = (void *)_heap_alloc(&_heap, num * size, sizeof(hnode_t));
-	memset(res, 0, num * size);
+	memset(res, 0, ALIGN(num * size, sizeof(hnode_t)));
 	return res;
 }
 


### PR DESCRIPTION
Size was not `ALIGN`ed, may result in too small a memset