### PR TITLE
Created some documentation for the FSS0 format.

### DIFF
--- a/docs/fss0.md
+++ b/docs/fss0.md
@@ -1,0 +1,56 @@
+# FSS0
+
+| Offset | Size     | Description                           |
+| ------ | -------- | ------------------------------------- |
+| 0x0    | 0x4      | Instruction to branch to startup code |
+| 0x4    | 0x4      | Offset of header                      |
+| 0x8    |          | Startup code                          |
+
+## Header
+
+| Offset | Size  | Description                          |
+| ------ | ----- | ------------------------------------ |
+| 0x0    | 0x4   | Magicnum "FSS0"                      |
+| 0x4    | 0x4   | Size of the entire file              |
+| 0x8    | 0x4   | Offset of startup code               |
+| 0xC    | 0x4   | Offset of content headers            |
+| 0x10   | 0x4   | Number of content headers            |
+| 0x14   | 0x4   | Maximum Horizon OS Supported         |
+| 0x18   | 0x4   | Atmosphere Version                   |
+| 0x1C   | 0x4   | First four bytes of the git revision | 
+
+## Content Header
+
+| Offset | Size  | Description       |
+| ------ | ----- | ----------------- |
+| 0x0    | 0x4   | Offset of content |
+| 0x4    | 0x4   | Size of content   |
+| 0x8    | 0x1   | Type              |
+| 0x9    | 0x1   | First flag        |
+| 0xA    | 0x1   | Second flag       |
+| 0xB    | 0x1   | Third flag        |
+| 0xC    | 0x4   | Reserved          |
+| 0x10   | 0xA   | Name              |
+
+### Content Header Types
+
+| Value | Description    |
+| ----- | -------------- |
+| 0x0   | Fusee Primary  |
+| 0x1   | Exosphere      |
+| 0x2   | LP0 Firmware   |
+| 0x3   | Reboot Stub    |
+| 0x4   | Sept Primary   |
+| 0x5   | Sept Secondary |
+| 0x6   | KIP            |
+| 0x7   | Bitmap         |
+| 0x8   | EmuMMC         |
+| 0x9   | Kernel Loader  |
+| 0xA   | Kernel         |
+
+### Content Header Flags
+
+| Value | Description  |
+| ----- | ------------ |
+| 0x0   | None         |
+| 0x1   | Experimental |


### PR DESCRIPTION
I know technically Hekate doesn't create these files, so it doesn't really make sense for this to be documented here. However I tried to submit this documentation to the Atmosphere repository and was denied because this file format is specifically for Hekate, and SciresM doesn't want to imply support for other non-hekate clients. (Also I originally had a few mistakes in my documentation.) All I'm trying to do is document this file format somewhere that can be easily found and digested for anyone who may need it in the future. Maybe you can talk some sense into SciresM or maybe suggest a better place for this documentation to belong.