### PR TITLE
BDK: types: add stdint header

### DIFF
--- a/bdk/utils/types.h
+++ b/bdk/utils/types.h
@@ -19,6 +19,7 @@
 #define _TYPES_H_
 
 #include <assert.h>
+#include <stdint.h>
 
 /* Types */
 typedef signed char s8;


### PR DESCRIPTION
On Fedora 35 - aarch64 using the provided arm compiler toolchain from redhat repository, build fails due to missing `<stdint.h>` header causing missing types such as `uintptr_t`