### PR TITLE
nyx: add new android id

### DIFF
--- a/nyx/nyx_gui/frontend/gui_tools_partition_manager.c
+++ b/nyx/nyx_gui/frontend/gui_tools_partition_manager.c
@@ -935,6 +935,13 @@ exit:
 static lv_res_t _action_reboot_recovery(lv_obj_t * btns, const char * txt)
 {
 	int btn_idx = lv_btnm_get_pressed(btns);
+	char id[8];
+
+	// Check if using new L4T-Loader Android
+	if (f_stat("bootloader/ini/android.ini", NULL))
+		id = "SWANDR";
+	else
+		id = "SWR-AND";
 
 	// Delete parent mbox.
 	mbox_action(btns, txt);
@@ -948,7 +955,7 @@ static lv_res_t _action_reboot_recovery(lv_obj_t * btns, const char * txt)
 		b_cfg->boot_cfg = BOOT_CFG_FROM_ID | BOOT_CFG_AUTOBOOT_EN;
 
 		// Set id to Android.
-		strcpy((char *)b_cfg->id, "SWANDR");
+		strcpy((char *)b_cfg->id, id);
 
 		void (*main_ptr)() = (void *)nyx_str->hekate;
 


### PR DESCRIPTION
Allow old and new ini's to exist briefly side-by side so releasetools can preserve user settings in L4T Loader migration for Android.

Planned Lineage 18.1 manual upgrade flow:
Drop new files (new ini named android.ini with id SWR-AND to match Ubuntu scheme) --> flash in partition manager --> reboot with new ini --> flash zip in recovery --> releasetools copies settings from uenv and old ini (00-android.ini, still in place) and deletes them. This provides a seamless upgrade experience for users coming from 17.1.

NOTE: fp'd to fix indentation type to match rest of file