### PR TITLE
Increase charging current limit when connected to a USB-PD source in Nyx

### DIFF
--- a/bdk/power/bq24193.c
+++ b/bdk/power/bq24193.c
@@ -164,6 +164,27 @@ void bq24193_enable_charger()
 	i2c_send_byte(I2C_1, BQ24193_I2C_ADDR, BQ24193_PORConfig, reg);
 }
 
+void bq24193_set_current_limit(u32 current_limit)
+{
+	u8 reg = bq24193_get_reg(BQ24193_InputSource);
+	reg &= ~BQ24193_INCONFIG_INLIMIT_MASK;
+
+	// select a predefined mode lower or equal to the requested limit
+	u8 inlimit_mode = 0;
+	if (current_limit >= 100)  inlimit_mode = 0;
+	if (current_limit >= 150)  inlimit_mode = 1;
+	if (current_limit >= 500)  inlimit_mode = 2;
+	if (current_limit >= 900)  inlimit_mode = 3;
+	if (current_limit >= 1200) inlimit_mode = 4;
+	if (current_limit >= 1500) inlimit_mode = 5;
+	if (current_limit >= 2000) inlimit_mode = 6;
+	if (current_limit >= 3000) inlimit_mode = 7;
+
+	reg |= inlimit_mode;
+
+	i2c_send_byte(I2C_1, BQ24193_I2C_ADDR, BQ24193_InputSource, reg);
+}
+
 void bq24193_fake_battery_removal()
 {
 	// Disable watchdog to keep BATFET disabled.

--- a/bdk/power/bq24193.h
+++ b/bdk/power/bq24193.h
@@ -19,6 +19,8 @@
 #ifndef __BQ24193_H_
 #define __BQ24193_H_
 
+#include <utils/types.h>
+
 #define BQ24193_I2C_ADDR 0x6B
 
 // REG 0 masks.
@@ -116,6 +118,7 @@ enum BQ24193_reg_prop {
 
 int bq24193_get_property(enum BQ24193_reg_prop prop, int *value);
 void bq24193_enable_charger();
+void bq24193_set_current_limit(u32 current_limit);
 void bq24193_fake_battery_removal();
 
 #endif /* __BQ24193_H_ */


### PR DESCRIPTION
When bm92t36 gets a PD connection established, set an appropriate input current level in bq24193.

This works fine when disconnecting/reconnecting to a different usb port, because bq24193 resets the input current level on reconnect, setting the appropriate safe value. With an appropriate USB charger, this will let the switch charge with max charging current - 2048 mA.

I do not change the charging current from the default, because I do not know would be a reasonable/safe value.

