### PR TITLE
nyx: add password lock

### DIFF
--- a/nyx/nyx_gui/config.c
+++ b/nyx/nyx_gui/config.c
@@ -56,6 +56,7 @@ void set_nyx_default_configuration()
 	n_cfg.timeoff        = 0;
 	n_cfg.home_screen    = 0;
 	n_cfg.verification   = 1;
+	n_cfg.password		 = 0;
 	n_cfg.ums_emmc_rw    = 0;
 	n_cfg.jc_disable     = 0;
 	n_cfg.jc_force_right = 0;
@@ -224,6 +225,10 @@ int create_nyx_config_entry(bool force_unmount)
 
 	f_puts("\nverification=", &fp);
 	itoa(n_cfg.verification, lbuf, 10);
+	f_puts(lbuf, &fp);
+
+	f_puts("\npassword=", &fp);
+	itoa(n_cfg.password, lbuf, 10);
 	f_puts(lbuf, &fp);
 
 	f_puts("\numsemmcrw=", &fp);

--- a/nyx/nyx_gui/config.h
+++ b/nyx/nyx_gui/config.h
@@ -50,6 +50,7 @@ typedef struct _nyx_config
 	u32 timeoff;
 	u32 home_screen;
 	u32 verification;
+	u32 password;
 	u32 ums_emmc_rw;
 	u32 jc_disable;
 	u32 jc_force_right;

--- a/nyx/nyx_gui/nyx.c
+++ b/nyx/nyx_gui/nyx.c
@@ -278,6 +278,8 @@ skip_main_cfg_parse:
 					n_cfg.home_screen    = atoi(kv->val);
 				else if (!strcmp("verification", kv->key))
 					n_cfg.verification   = atoi(kv->val);
+				else if (!strcmp("password", kv->key))
+					n_cfg.password       = atoi(kv->val);
 				else if (!strcmp("umsemmcrw",    kv->key))
 					n_cfg.ums_emmc_rw    = atoi(kv->val) == 1;
 				else if (!strcmp("jcdisable",    kv->key))


### PR DESCRIPTION
This PR adds a simple password lock to nyx. The password is currently stored in plain-text in the `nyx.ini` config.
It's fully functional but there may be some code that can be shared between the `gui.c` and `gui_options.c`.

This feature is mainly intended for modchip switch models to prevent others from accidentally tampering with your config or getting you banned because they aren't into switch modding.
