### PR TITLE
Read usb3 from system_settings.ini even without exosphere.ini

### DIFF
--- a/bootloader/hos/secmon_exo.c
+++ b/bootloader/hos/secmon_exo.c
@@ -241,29 +241,29 @@ void config_exosphere(launch_ctxt_t *ctxt, u32 warmboot_base)
 				}
 				break;
 			}
+		}
 
-			// Parse usb mtim settings. Avoid parsing if it's overridden.
-			if (!ctxt->exo_ctx.usb3_force)
+		// Parse usb mtim settings. Avoid parsing if it's overridden.
+		if (!ctxt->exo_ctx.usb3_force)
+		{
+			LIST_INIT(ini_sys_sections);
+			if (ini_parse(&ini_sys_sections, "atmosphere/config/system_settings.ini", false))
 			{
-				LIST_INIT(ini_sys_sections);
-				if (ini_parse(&ini_sys_sections, "atmosphere/config/system_settings.ini", false))
+				LIST_FOREACH_ENTRY(ini_sec_t, ini_sec, &ini_sys_sections, link)
 				{
-					LIST_FOREACH_ENTRY(ini_sec_t, ini_sec, &ini_sys_sections, link)
-					{
-						// Only parse usb section.
-						if (!(ini_sec->type == INI_CHOICE) || strcmp(ini_sec->name, "usb"))
-							continue;
+					// Only parse usb section.
+					if (!(ini_sec->type == INI_CHOICE) || strcmp(ini_sec->name, "usb"))
+						continue;
 
-						LIST_FOREACH_ENTRY(ini_kv_t, kv, &ini_sec->kvs, link)
+					LIST_FOREACH_ENTRY(ini_kv_t, kv, &ini_sec->kvs, link)
+					{
+						if (!strcmp("usb30_force_enabled", kv->key))
 						{
-							if (!strcmp("usb30_force_enabled", kv->key))
-							{
-								usb3_force = !strcmp("u8!0x1", kv->val);
-								break; // Only parse usb30_force_enabled key.
-							}
+							usb3_force = !strcmp("u8!0x1", kv->val);
+							break; // Only parse usb30_force_enabled key.
 						}
-						break;
 					}
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
Currently the code to read `usb30_force_enabled` from atmosphere's system_settings.ini is inside the if condition of `ini_parse(&ini_exo_sections, "exosphere.ini", false)`, which means it only runs if exosphere.ini exists. This seems confusing and is not documented. It is also not how this worked when initially added to this repository.

This code was moved inside the if block as part of 622f7124ac46be7efc93cd531093e17276352136 (fss: remove dynamic path) although that commit does mot mention any deliberate functional changes affecting cases not trying to use dynamic path, so it getting nested in the previous if block looks accidental.

This change simply moves the code outside that block like it used to be, and de-indents it one level to match.

If the current behavior is intended then the description for `usb3force` should probably be updated to say something like:
> Overrides system settings mitm config `usb30_force_enabled`. If that key doesn't exist, `system_settings.ini` will be used<ins>, but only if `exosphere.ini` also exists</ins>.