### PR TITLE
nyx: add confirmlaunch boot entry kv

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ There are four possible type of entries. "**[ ]**": Boot entry, "**{ }**": Capti
 | id=IDNAME              | Identifies boot entry for forced boot via id. Max 7 chars. |
 | logopath={FILE path}   | If it exists, it will load the specified bitmap. Otherwise `bootloader/bootlogo.bmp` will be used if exists |
 | icon={FILE path}       | Force Nyx to use the icon defined here. If this is not found, it will check for a bmp named as the boot entry ([Test 2] -> `bootloader/res/Test 2.bmp`). Otherwise defaults will be used. |
+| confirmlaunch=1       | 0: Disable, 1: Show confirmation dialog before launching this boot entry. |
 
 
 **Note1**: When using the wildcard (`/*`) with `kip1` you can still use the normal `kip1` after that to load extra single kips.

--- a/nyx/nyx_gui/frontend/gui.c
+++ b/nyx/nyx_gui/frontend/gui.c
@@ -1188,7 +1188,7 @@ static lv_res_t _create_mbox_confirmlaunch(char *btn_name, u32 entry_idx, bool i
 
 	char confirm_message[256];
 	s_printf(confirm_message, 
-		"Are you sure you would like to launch\n#FF8000%s?#", 
+		"Are you sure you would like to launch\n#FF8000 %s#?", 
 		btn_name);
 	lv_mbox_set_text(mbox, confirm_message);
 	lv_mbox_add_btns(mbox, mbox_btn_map, _confirmlaunch_action);


### PR DESCRIPTION
Have wanted this feature for a while, been using a personal build with something like this and figured I'd see if it was something you were interested in. This PR allows you to add an additional confirm dialog to boot entries. I built this because I have a clean sysnand boot option and a dirty sysnand boot option, and I didn't want to accidentally hit the dirty boot option without both setting sysnand to offline mode and having a nand backup ready.

Forgive me if the code is a little strange, I generally write TypeScript, Java, and _some_ C++.
<img width="1484" height="847" alt="Screenshot 2025-08-13 at 7 56 05 PM" src="https://github.com/user-attachments/assets/78f108b3-965b-4556-ac9e-e1e6d35ae8fc" />