### PR TITLE
hekate: enable link time optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,11 @@ WARNINGS := -Wall -Wsign-compare -Wtype-limits -Wno-array-bounds -Wno-stringop-o
 #-fno-delete-null-pointer-checks
 #-Wstack-usage=byte-size -fstack-usage
 
+OPTFLAGS := -O2 -g -gdwarf-4 -ffunction-sections -fdata-sections -fomit-frame-pointer -finline-limit=4 -fno-keep-static-consts -fira-loop-pressure
+LTOFLAGS := -flto -ffat-lto-objects
 ARCH := -march=armv4t -mtune=arm7tdmi -mthumb -mthumb-interwork $(WARNINGS)
-CFLAGS = $(ARCH) -O2 -g -gdwarf-4 -nostdlib -ffunction-sections -fdata-sections -fomit-frame-pointer -fno-inline -std=gnu11 $(CUSTOMDEFINES)
-LDFLAGS = $(ARCH) -nostartfiles -lgcc -Wl,--nmagic,--gc-sections -Xlinker --defsym=IPL_LOAD_ADDR=$(IPL_LOAD_ADDR)
+CFLAGS = $(ARCH) $(OPTFLAGS) $(LTOFLAGS) -nostdlib -std=gnu11 $(CUSTOMDEFINES)
+LDFLAGS = $(ARCH) $(LTOFLAGS) -nostartfiles -lgcc -Wl,--nmagic,--gc-sections -Xlinker --defsym=IPL_LOAD_ADDR=$(IPL_LOAD_ADDR)
 
 MODULEDIRS := $(wildcard modules/*)
 NYXDIR := $(wildcard nyx)

--- a/bdk/soc/hw_init.c
+++ b/bdk/soc/hw_init.c
@@ -372,7 +372,7 @@ static void _config_regulators(bool tegra_t210, bool nx_hoag)
 	}
 }
 
-void hw_init()
+void __attribute__((noinline)) hw_init()
 {
 	// Get Chip ID and SKU.
 	bool tegra_t210 = hw_get_chip_id() == GP_HIDREV_MAJOR_T210;

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -1430,7 +1430,9 @@ menu_t menu_top = { ment_top, "hekate v6.5.1", 0, 0 };
 
 extern void pivot_stack(u32 stack_top);
 
-void ipl_main()
+static void ipl_main_real(void);
+
+void __attribute__((noreturn)) ipl_main()
 {
 	// Override DRAM ID if needed.
 	if (ipl_ver.rcfg.rsvd_flags & RSVD_FLAG_DRAM_8GB)
@@ -1442,6 +1444,11 @@ void ipl_main()
 	// Pivot the stack under IPL. (Only max 4KB is needed).
 	pivot_stack(IPL_LOAD_ADDR);
 
+	ipl_main_real();
+}
+
+static void __attribute__((noinline)) __attribute__((noreturn)) ipl_main_real(void)
+{
 	// Place heap at a place outside of L4T/HOS configuration and binaries.
 	heap_init((void *)IPL_HEAP_START);
 

--- a/nyx/Makefile
+++ b/nyx/Makefile
@@ -91,8 +91,10 @@ WARNINGS := -Wall -Wsign-compare -Wtype-limits -Wno-array-bounds -Wno-stringop-o
 #-Wstack-usage=byte-size -fstack-usage
 
 ARCH := -march=armv4t -mtune=arm7tdmi -mthumb-interwork $(WARNINGS)
-CFLAGS = $(ARCH) -O2 -g -gdwarf-4 -nostdlib -ffunction-sections -fdata-sections -fomit-frame-pointer -std=gnu11 $(CUSTOMDEFINES)
-LDFLAGS = $(ARCH) -nostartfiles -lgcc -Wl,--nmagic,--gc-sections -Xlinker --defsym=NYX_LOAD_ADDR=$(NYX_LOAD_ADDR)
+OPTFLAGS := -O2 -g -gdwarf-4 -ffunction-sections -fdata-sections -fomit-frame-pointer -finline-limit=4 -fno-keep-static-consts -fira-loop-pressure
+LTOFLAGS := -flto -ffat-lto-objects
+CFLAGS = $(ARCH) $(OPTFLAGS) $(LTOFLAGS) -nostdlib -std=gnu11 $(CUSTOMDEFINES)
+LDFLAGS = $(ARCH) $(LTOFLAGS) -nostartfiles -lgcc -Wl,--nmagic,--gc-sections -Xlinker --defsym=NYX_LOAD_ADDR=$(NYX_LOAD_ADDR)
 
 ifndef NYXECHO
 T := $(shell $(MAKE) $(BUILDDIR)/$(TARGET).elf --no-print-directory -nrRf $(firstword $(MAKEFILE_LIST)) NYXECHO="NYXOBJ" | grep -c "NYXOBJ")


### PR DESCRIPTION
This PR is probably more useful for BDK consumers than Hekate itself, but I've decided to upstream it in case there's interest in having this change to cut down on payload size and potentially get better compiler optimizations.

Enabling LTO cuts around ~3kB from the uncompressed BPMP payload and around ~36kB from Nyx.

```
--------------------------------------
Nyx size: 468149 Bytes
--------------------------------------
--------------------------------------
hekate size:
Uncompr:  133433 Bytes
Payload:  109546 Bytes
--------------------------------------
```

```
--------------------------------------
Nyx size: 431989 Bytes
--------------------------------------
--------------------------------------
hekate size:
Uncompr:  130117 Bytes
Payload:  107806 Bytes
--------------------------------------
```