### PR TITLE
Colorize battery and SoC temperature

### DIFF
--- a/nyx/nyx_gui/frontend/gui.c
+++ b/nyx/nyx_gui/frontend/gui.c
@@ -1360,6 +1360,27 @@ static void _create_tab_about(lv_theme_t * th, lv_obj_t * parent)
 	lv_label_set_text(lbl_ver, version);
 }
 
+const char *gui_temp_color(int temp_c10, bool is_battery)
+{
+	if (is_battery)
+	{
+		// Battery charge window is 0-45 °C; >50 is critical.
+		if (temp_c10 <    0) return "00BBFF";
+		if (temp_c10 <  100) return "33CCFF";
+		if (temp_c10 <  350) return "88CC00";
+		if (temp_c10 <  420) return "FFDD00";
+		if (temp_c10 <  500) return "FF8000";
+		return                      "FF3030";
+	}
+
+	// SoC: fan @41 °C, throttle ~75 °C, hard limit ~95 °C.
+	if (temp_c10 <  300) return "33CCFF";
+	if (temp_c10 <  500) return "88CC00";
+	if (temp_c10 <  650) return "FFDD00";
+	if (temp_c10 <  800) return "FF8000";
+	return                      "FF3030";
+}
+
 static void _update_status_bar(void *params)
 {
 	static char *label = NULL;
@@ -1387,10 +1408,18 @@ static void _update_status_bar(void *params)
 		label = (char *)malloc(512);
 
 	// Set time and SoC temperature.
-	s_printf(label, "%02d:%02d "SYMBOL_DOT" "SYMBOL_TEMPERATURE" %02d.%d",
-		time.hour, time.min, soc_temp_dec, (soc_temp & 0xFF) / 10);
+	const char *soc_color = gui_temp_color((int)soc_temp_dec * 10, false);
+	s_printf(label, "%02d:%02d "SYMBOL_DOT" #%s "SYMBOL_TEMPERATURE" %02d.%d#",
+		time.hour, time.min, soc_color, soc_temp_dec, (soc_temp & 0xFF) / 10);
 
 	lv_label_set_text(status_bar.time_temp, label);
+
+	// "°" and "C" are separate labels (smaller font); recolor them to match.
+	char unit_buf[24];
+	s_printf(unit_buf, " #%s "SYMBOL_DOT"#", soc_color);
+	lv_label_set_text(status_bar.temp_symbol, unit_buf);
+	s_printf(unit_buf, "#%s C#", soc_color);
+	lv_label_set_text(status_bar.temp_degrees, unit_buf);
 
 	lv_obj_realign(status_bar.temp_symbol);
 	lv_obj_realign(status_bar.temp_degrees);
@@ -2190,16 +2219,19 @@ static void _create_status_bar(lv_theme_t * th)
 
 	// Time, temperature.
 	lv_obj_t *lbl_time_temp = lv_label_create(status_bar_bg, NULL);
+	lv_label_set_recolor(lbl_time_temp, true);
 	lv_label_set_text(lbl_time_temp, "00:00 "SYMBOL_DOT" "SYMBOL_TEMPERATURE" 00.0");
 	lv_obj_align(lbl_time_temp, lbl_left, LV_ALIGN_OUT_RIGHT_MID, 0, 0);
 	status_bar.time_temp = lbl_time_temp;
 
 	lbl_left = lv_label_create(status_bar_bg, NULL);
+	lv_label_set_recolor(lbl_left, true);
 	lv_label_set_text(lbl_left, " "SYMBOL_DOT);
 	lv_obj_align(lbl_left, lbl_time_temp, LV_ALIGN_OUT_RIGHT_MID, 0, -LV_DPI / 14);
 	status_bar.temp_symbol = lbl_left;
 
 	lv_obj_t *lbl_degrees = lv_label_create(status_bar_bg, NULL);
+	lv_label_set_recolor(lbl_degrees, true);
 	lv_label_set_text(lbl_degrees, "C");
 	lv_obj_align(lbl_degrees, lbl_left, LV_ALIGN_OUT_RIGHT_MID, LV_DPI / 50, LV_DPI / 14);
 	status_bar.temp_degrees = lbl_degrees;

--- a/nyx/nyx_gui/frontend/gui.h
+++ b/nyx/nyx_gui/frontend/gui.h
@@ -84,4 +84,7 @@ lv_res_t nyx_generic_onoff_toggle(lv_obj_t *btn);
 void manual_system_maintenance(bool refresh);
 void nyx_load_and_run();
 
+// temp_c10 is degrees Celsius * 10. is_battery selects battery vs SoC thresholds.
+const char *gui_temp_color(int temp_c10, bool is_battery);
+
 #endif

--- a/nyx/nyx_gui/frontend/gui_info.c
+++ b/nyx/nyx_gui/frontend/gui_info.c
@@ -2758,7 +2758,9 @@ static lv_res_t _create_window_battery_status(lv_obj_t *btn)
 		s_printf(txt_buf + strlen(txt_buf), "%d mV\n", value);
 
 		max17050_get_property(MAX17050_TEMP, &value);
-		s_printf(txt_buf + strlen(txt_buf), "%d.%d oC\n\n\n", value / 10, (value >= 0 ? value : (~value + 1)) % 10);
+		s_printf(txt_buf + strlen(txt_buf), "#%s %d.%d oC#\n\n\n",
+			gui_temp_color(value, true),
+			value / 10, (value >= 0 ? value : (~value + 1)) % 10);
 	}
 	else
 		strcpy(txt_buf, "\n#FF8000 "SYMBOL_WARNING" Error!#\n\n\n\n\n\n\n\n\n\n\n\n\n");
@@ -2863,19 +2865,19 @@ static lv_res_t _create_window_battery_status(lv_obj_t *btn)
 		switch (value)
 		{
 		case 0:
-			strcat(txt_buf, "Normal");
+			strcat(txt_buf, "#88CC00 Normal#");
 			break;
 		case 2:
-			strcat(txt_buf, "Warm");
+			strcat(txt_buf, "#FFDD00 Warm#");
 			break;
 		case 3:
-			strcat(txt_buf, "Cool");
+			strcat(txt_buf, "#33CCFF Cool#");
 			break;
 		case 5:
-			strcat(txt_buf, "#FF8000 Cold#");
+			strcat(txt_buf, "#00BBFF Cold#");
 			break;
 		case 6:
-			strcat(txt_buf, "#FF8000 Hot#");
+			strcat(txt_buf, "#FF3030 Hot#");
 			break;
 		default:
 			s_printf(txt_buf + strlen(txt_buf), "Unknown (%d)", value);


### PR DESCRIPTION
Tints the temperature readings on the status bar and Battery Info screen by range (cool/normal/warm/hot/critical), so an overheating SoC or out-of-window battery stands out at a glance.