### PR TITLE
nyx: add resized SD file emuMMC creation

### DIFF
--- a/bdk/storage/nx_emmc_bis.c
+++ b/bdk/storage/nx_emmc_bis.c
@@ -26,6 +26,7 @@
 #include <storage/emmc.h>
 #include <storage/sd.h>
 #include <storage/sdmmc.h>
+#include <libs/fatfs/ff.h>
 #include <utils/types.h>
 
 #define BIS_CLUSTER_SECTORS   32
@@ -53,9 +54,81 @@ typedef struct _bis_cache_t
 static u8  ks_crypt = 0;
 static u8  ks_tweak = 0;
 static u32 emu_offset = 0;
+static bool emu_file_backend = false;
+static u32  emu_file_part_sectors = 0;
+static char emu_file_path[0x200];
 static emmc_part_t *system_part = NULL;
 static u32 *cache_lookup_tbl = (u32 *)NX_BIS_LOOKUP_ADDR;
 static bis_cache_t *bis_cache = (bis_cache_t *)NX_BIS_CACHE_ADDR;
+
+static void _nx_emmc_bis_update_file_path(u32 file_part)
+{
+	u32 path_len = strlen(emu_file_path);
+
+	if (file_part >= 10)
+	{
+		char tmp[12];
+		u32 idx = sizeof(tmp) - 1;
+		tmp[idx] = 0;
+
+		do
+		{
+			tmp[--idx] = '0' + (file_part % 10);
+			file_part /= 10;
+		}
+		while (file_part);
+
+		strcpy(emu_file_path + path_len - 2, &tmp[idx]);
+	}
+	else
+	{
+		emu_file_path[path_len - 2] = '0';
+		emu_file_path[path_len - 1] = '0' + file_part;
+		emu_file_path[path_len] = 0;
+	}
+}
+
+static int _nx_emmc_bis_file_read_write(u32 sector, u32 count, void *buff, bool write)
+{
+	FIL fp;
+	u8 *buf = (u8 *)buff;
+
+	while (count)
+	{
+		u32 file_part = sector / emu_file_part_sectors;
+		u32 file_sector = sector % emu_file_part_sectors;
+		u32 sector_count = MIN(count, emu_file_part_sectors - file_sector);
+
+		_nx_emmc_bis_update_file_path(file_part);
+
+		if (f_open(&fp, emu_file_path, write ? FA_WRITE : FA_READ))
+			return 1;
+
+		f_lseek(&fp, (u64)file_sector << 9);
+
+		if (write)
+		{
+			if (f_write(&fp, buf, (u64)sector_count << 9, NULL))
+			{
+				f_close(&fp);
+				return 1;
+			}
+		}
+		else if (f_read(&fp, buf, (u64)sector_count << 9, NULL))
+		{
+			f_close(&fp);
+			return 1;
+		}
+
+		f_close(&fp);
+
+		sector += sector_count;
+		count  -= sector_count;
+		buf    += sector_count * EMMC_BLOCKSIZE;
+	}
+
+	return 0;
+}
 
 static int nx_emmc_bis_write_block(u32 sector, u32 count, void *buff, bool flush)
 {
@@ -95,7 +168,9 @@ static int nx_emmc_bis_write_block(u32 sector, u32 count, void *buff, bool flush
 		return 1; // Encryption error.
 
 	// If not reading from cache, do a regular read and decrypt.
-	if (!emu_offset)
+	if (emu_file_backend)
+		res = _nx_emmc_bis_file_read_write(system_part->lba_start + sector, count, bis_cache->dma_buff, true);
+	else if (!emu_offset)
 		res = emmc_part_write(system_part, sector, count, bis_cache->dma_buff);
 	else
 		res = sdmmc_storage_write(&sd_storage, emu_offset + system_part->lba_start + sector, count, bis_cache->dma_buff);
@@ -155,7 +230,9 @@ static int nx_emmc_bis_read_block_normal(u32 sector, u32 count, void *buff)
 	u32  sector_in_cluster = sector % BIS_CLUSTER_SECTORS;
 
 	// If not reading from cache, do a regular read and decrypt.
-	if (!emu_offset)
+	if (emu_file_backend)
+		res = _nx_emmc_bis_file_read_write(system_part->lba_start + sector, count, bis_cache->dma_buff, false);
+	else if (!emu_offset)
 		res = emmc_part_read(system_part, sector, count, bis_cache->dma_buff);
 	else
 		res = sdmmc_storage_read(&sd_storage, emu_offset + system_part->lba_start + sector, count, bis_cache->dma_buff);
@@ -212,7 +289,9 @@ static int nx_emmc_bis_read_block_cached(u32 sector, u32 count, void *buff)
 	cache_lookup_tbl[cluster] = bis_cache->top_idx;
 
 	// Read the whole cluster the sector resides in.
-	if (!emu_offset)
+	if (emu_file_backend)
+		res = _nx_emmc_bis_file_read_write(system_part->lba_start + cluster_sector, BIS_CLUSTER_SECTORS, bis_cache->dma_buff, false);
+	else if (!emu_offset)
 		res = emmc_part_read(system_part, cluster_sector, BIS_CLUSTER_SECTORS, bis_cache->dma_buff);
 	else
 		res = sdmmc_storage_read(&sd_storage, emu_offset + system_part->lba_start + cluster_sector, BIS_CLUSTER_SECTORS, bis_cache->dma_buff);
@@ -292,6 +371,22 @@ int nx_emmc_bis_write(u32 sector, u32 count, void *buff)
 	return 0;
 }
 
+void nx_emmc_bis_set_file_backend(const char *path, u32 file_part_sectors)
+{
+	emu_file_backend = path && file_part_sectors;
+	emu_file_part_sectors = file_part_sectors;
+
+	if (emu_file_backend)
+	{
+		strcpy(emu_file_path, path);
+		if (emu_file_path[strlen(emu_file_path) - 1] != '/')
+			strcat(emu_file_path, "/");
+		strcat(emu_file_path, "00");
+	}
+	else
+		emu_file_path[0] = 0;
+}
+
 void nx_emmc_bis_init(emmc_part_t *part, bool enable_cache, u32 emummc_offset)
 {
 	system_part = part;
@@ -322,4 +417,5 @@ void nx_emmc_bis_end()
 {
 	_nx_emmc_bis_flush_cache();
 	system_part = NULL;
+	nx_emmc_bis_set_file_backend(NULL, 0);
 }

--- a/bdk/storage/nx_emmc_bis.h
+++ b/bdk/storage/nx_emmc_bis.h
@@ -237,6 +237,7 @@ typedef struct _nx_emmc_cal0_t
 
 int  nx_emmc_bis_read(u32 sector, u32 count, void *buff);
 int  nx_emmc_bis_write(u32 sector, u32 count, void *buff);
+void nx_emmc_bis_set_file_backend(const char *path, u32 file_part_sectors);
 void nx_emmc_bis_init(emmc_part_t *part, bool enable_cache, u32 emummc_offset);
 void nx_emmc_bis_end();
 

--- a/nyx/nyx_gui/frontend/fe_emummc_tools.c
+++ b/nyx/nyx_gui/frontend/fe_emummc_tools.c
@@ -32,6 +32,7 @@
 
 #define OUT_FILENAME_SZ      128
 #define NUM_SECTORS_PER_ITER 8192 // 4MB Cache.
+#define FILE_EMUMMC_SPLIT_SIZE      0xFE000000
 
 void load_emummc_cfg(emummc_cfg_t *emu_info)
 {
@@ -145,7 +146,7 @@ static int _dump_emummc_file_part(emmc_tool_gui_t *gui, char *sd_path, sdmmc_sto
 	static const u32 FAT32_FILESIZE_LIMIT = 0xFFFFFFFF;
 	static const u32 SECTORS_TO_MIB_COEFF = 11;
 
-	u32 multipartSplitSize = 0xFE000000;
+	u32 multipartSplitSize = FILE_EMUMMC_SPLIT_SIZE;
 	u32 totalSectors = part->lba_end - part->lba_start + 1;
 	u32 currPartIdx = 0;
 	u32 numSplitParts = 0;
@@ -353,11 +354,188 @@ static int _dump_emummc_file_part(emmc_tool_gui_t *gui, char *sd_path, sdmmc_sto
 	return 0;
 }
 
-void dump_emummc_file(emmc_tool_gui_t *gui)
+static int _emummc_file_write_sectors(const char *base_path, u32 file_part_sectors, u32 sector, u32 count, const void *buff)
+{
+	FIL fp;
+	char path[OUT_FILENAME_SZ];
+	const u8 *buf = (const u8 *)buff;
+	u32 path_len;
+
+	strcpy(path, base_path);
+	path_len = strlen(path);
+	strcat(path, "00");
+
+	while (count)
+	{
+		u32 file_part = sector / file_part_sectors;
+		u32 file_sector = sector % file_part_sectors;
+		u32 sector_count = MIN(count, file_part_sectors - file_sector);
+
+		update_emummc_base_folder(path, path_len, file_part);
+
+		if (f_open(&fp, path, FA_WRITE))
+			return 1;
+
+		f_lseek(&fp, (u64)file_sector << 9);
+		if (f_write(&fp, buf, (u64)sector_count << 9, NULL))
+		{
+			f_close(&fp);
+			return 1;
+		}
+
+		f_close(&fp);
+
+		sector += sector_count;
+		count  -= sector_count;
+		buf    += sector_count * EMMC_BLOCKSIZE;
+	}
+
+	return 0;
+}
+
+static int _finalize_resized_file_emummc(emmc_tool_gui_t *gui, const char *base_path, u32 resized_count, u32 file_part_sectors)
+{
+	u32 user_offset = 0;
+	u8 *buf = (u8 *)MIXD_BUF_ALIGNED;
+
+	LIST_INIT(gpt_parsed);
+	emmc_gpt_parse(&gpt_parsed);
+	emmc_part_t *user_part_src = emmc_part_find(&gpt_parsed, "USER");
+	if (!user_part_src)
+	{
+		s_printf(gui->txt_buf, "\n#FFDD00 USER partition not found!#\n");
+		lv_label_ins_text(gui->label_log, LV_LABEL_POS_LAST, gui->txt_buf);
+		manual_system_maintenance(true);
+		emmc_gpt_free(&gpt_parsed);
+		return 1;
+	}
+
+	user_offset = user_part_src->lba_start;
+	emmc_gpt_free(&gpt_parsed);
+	if (resized_count <= user_offset + 33)
+	{
+		s_printf(gui->txt_buf, "\n#FFDD00 Resized emuMMC is too small!#\n");
+		lv_label_ins_text(gui->label_log, LV_LABEL_POS_LAST, gui->txt_buf);
+		manual_system_maintenance(true);
+		return 1;
+	}
+
+	// Calculate USER size and set it for FatFS.
+	u32 user_sectors = resized_count - user_offset - 33;
+	user_sectors = ALIGN_DOWN(user_sectors, 0x20); // Align down to cluster size.
+	disk_set_info(DRIVE_EMU, SET_SECTOR_COUNT, &user_sectors);
+
+	// Initialize BIS for file based emuMMC.
+	emmc_part_t user_part = {0};
+	user_part.lba_start = user_offset;
+	user_part.lba_end = user_offset + user_sectors - 1;
+	strcpy(user_part.name, "USER");
+	nx_emmc_bis_set_file_backend(base_path, file_part_sectors);
+	nx_emmc_bis_init(&user_part, true, 0);
+
+	s_printf(gui->txt_buf, "Formatting resized USER... ");
+	lv_label_ins_text(gui->label_log, LV_LABEL_POS_LAST, gui->txt_buf);
+	manual_system_maintenance(true);
+
+	// Format USER partition as FAT32 with 16KB cluster and PRF2SAFE.
+	u8 *buff = malloc(SZ_4M);
+	int mkfs_error = f_mkfs("emu:", FM_FAT32 | FM_SFD | FM_PRF2, 16384, buff, SZ_4M);
+	free(buff);
+
+	// Mount sd card back.
+	sd_mount();
+
+	if (mkfs_error)
+	{
+		s_printf(gui->txt_buf, "#FF0000 Failed (%d)!#\nPlease try again...\n", mkfs_error);
+		lv_label_ins_text(gui->label_log, LV_LABEL_POS_LAST, gui->txt_buf);
+		nx_emmc_bis_end();
+
+		return 1;
+	}
+	lv_label_ins_text(gui->label_log, LV_LABEL_POS_LAST, "Done!\n");
+
+	// Flush BIS cache, deinit, clear BIS keys slots and reinstate SBK.
+	nx_emmc_bis_end();
+	hos_bis_keys_clear();
+
+	s_printf(gui->txt_buf, "Writing resized GPT... ");
+	lv_label_ins_text(gui->label_log, LV_LABEL_POS_LAST, gui->txt_buf);
+	manual_system_maintenance(true);
+
+	// Read MBR, GPT and backup GPT from eMMC.
+	mbr_t mbr;
+	gpt_t *gpt = zalloc(sizeof(gpt_t));
+	gpt_header_t gpt_hdr_backup;
+	sdmmc_storage_read(&emmc_storage, 0, 1, &mbr);
+	sdmmc_storage_read(&emmc_storage, 1, sizeof(gpt_t) >> 9, gpt);
+	sdmmc_storage_read(&emmc_storage, gpt->header.alt_lba, 1, &gpt_hdr_backup);
+
+	// Find USER partition.
+	u32 gpt_entry_idx = 0;
+	for (gpt_entry_idx = 0; gpt_entry_idx < gpt->header.num_part_ents; gpt_entry_idx++)
+		if (!memcmp(gpt->entries[gpt_entry_idx].name, (char[]) { 'U', 0, 'S', 0, 'E', 0, 'R', 0 }, 8))
+			break;
+
+	if (gpt_entry_idx >= gpt->header.num_part_ents)
+	{
+		s_printf(gui->txt_buf, "\n#FF0000 No USER partition...#\nPlease try again...\n");
+		lv_label_ins_text(gui->label_log, LV_LABEL_POS_LAST, gui->txt_buf);
+		free(gpt);
+
+		return 1;
+	}
+
+	// Set new emuMMC size and USER size.
+	mbr.partitions[0].size_sct = resized_count - 1; // Exclude MBR sector.
+	gpt->entries[gpt_entry_idx].lba_end = user_part.lba_end;
+
+	// Update Main GPT.
+	gpt->header.alt_lba = resized_count - 1;
+	gpt->header.last_use_lba = resized_count - 34;
+	gpt->header.part_ents_crc32 = crc32_calc(0, (const u8 *)gpt->entries, sizeof(gpt_entry_t) * gpt->header.num_part_ents);
+	gpt->header.crc32 = 0; // Set to 0 for calculation.
+	gpt->header.crc32 = crc32_calc(0, (const u8 *)&gpt->header, gpt->header.size);
+
+	// Update Backup GPT.
+	memcpy(&gpt_hdr_backup, &gpt->header, sizeof(gpt_header_t));
+	gpt_hdr_backup.my_lba = resized_count - 1;
+	gpt_hdr_backup.alt_lba = 1;
+	gpt_hdr_backup.part_ent_lba = resized_count - 33;
+	gpt_hdr_backup.crc32 = 0; // Set to 0 for calculation.
+	gpt_hdr_backup.crc32 = crc32_calc(0, (const u8 *)&gpt_hdr_backup, gpt_hdr_backup.size);
+
+	int res = 0;
+	res |= _emummc_file_write_sectors(base_path, file_part_sectors, gpt->header.my_lba, sizeof(gpt_t) >> 9, gpt);
+	res |= _emummc_file_write_sectors(base_path, file_part_sectors, gpt_hdr_backup.part_ent_lba, (sizeof(gpt_entry_t) * 128) >> 9, gpt->entries);
+	res |= _emummc_file_write_sectors(base_path, file_part_sectors, gpt_hdr_backup.my_lba, 1, &gpt_hdr_backup);
+	res |= _emummc_file_write_sectors(base_path, file_part_sectors, 0, 1, &mbr);
+
+	// Clear nand patrol.
+	memset(buf, 0, EMMC_BLOCKSIZE);
+	res |= _emummc_file_write_sectors(base_path, file_part_sectors, NAND_PATROL_SECTOR, 1, buf);
+
+	free(gpt);
+
+	if (res)
+	{
+		s_printf(gui->txt_buf, "#FF0000 Failed!#\nPlease try again...\n");
+		lv_label_ins_text(gui->label_log, LV_LABEL_POS_LAST, gui->txt_buf);
+
+		return 1;
+	}
+
+	lv_label_ins_text(gui->label_log, LV_LABEL_POS_LAST, "Done!\n");
+
+	return 0;
+}
+
+void dump_emummc_file(emmc_tool_gui_t *gui, u32 resized_count)
 {
 	int res = 1;
 	int base_len = 0;
 	u32 timer = 0;
+	u32 file_part_sectors = FILE_EMUMMC_SPLIT_SIZE / EMMC_BLOCKSIZE;
 
 	char *txt_buf = (char *)malloc(SZ_16K);
 	gui->base_path = (char *)malloc(OUT_FILENAME_SZ);
@@ -383,6 +561,13 @@ void dump_emummc_file(emmc_tool_gui_t *gui)
 	if (emmc_initialize(false))
 	{
 		lv_label_set_text(gui->label_info, "#FFDD00 Failed to init eMMC!#");
+		goto out;
+	}
+
+	if (resized_count && !emummc_raw_derive_bis_keys())
+	{
+		s_printf(gui->txt_buf, "#FFDD00 For formatting USER partition,#\n#FFDD00 BIS keys are needed!#\n");
+		lv_label_ins_text(gui->label_log, LV_LABEL_POS_LAST, gui->txt_buf);
 		goto out;
 	}
 
@@ -455,8 +640,16 @@ void dump_emummc_file(emmc_tool_gui_t *gui)
 	emmc_part_t rawPart;
 	memset(&rawPart, 0, sizeof(rawPart));
 	rawPart.lba_start = 0;
-	rawPart.lba_end = RAW_AREA_NUM_SECTORS - 1;
 	strcpy(rawPart.name, "GPP");
+
+	if (resized_count)
+	{
+		if (RAW_AREA_NUM_SECTORS < resized_count)
+			resized_count = RAW_AREA_NUM_SECTORS;
+		rawPart.lba_end = resized_count - 1;
+	}
+	else
+		rawPart.lba_end = RAW_AREA_NUM_SECTORS - 1;
 
 	s_printf(txt_buf, "#00DDFF %02d: %s#\n#00DDFF Range: 0x%08X - 0x%08X#\n\n",
 		i, rawPart.name, rawPart.lba_start, rawPart.lba_end);
@@ -470,7 +663,15 @@ void dump_emummc_file(emmc_tool_gui_t *gui)
 	if (res)
 		s_printf(txt_buf, "#FFDD00 Failed!#\n");
 	else
+	{
 		s_printf(txt_buf, "Done!\n");
+		lv_label_ins_text(gui->label_log, LV_LABEL_POS_LAST, txt_buf);
+		manual_system_maintenance(true);
+
+		if (resized_count)
+			res = _finalize_resized_file_emummc(gui, gui->base_path, resized_count, file_part_sectors);
+		txt_buf[0] = 0;
+	}
 
 	lv_label_ins_text(gui->label_log, LV_LABEL_POS_LAST, txt_buf);
 	manual_system_maintenance(true);

--- a/nyx/nyx_gui/frontend/fe_emummc_tools.h
+++ b/nyx/nyx_gui/frontend/fe_emummc_tools.h
@@ -31,7 +31,7 @@ typedef struct _emummc_cfg_t
 
 void load_emummc_cfg(emummc_cfg_t *emu_info);
 void save_emummc_cfg(u32 part_idx, u32 sector_start, const char *path);
-void dump_emummc_file(emmc_tool_gui_t *gui);
+void dump_emummc_file(emmc_tool_gui_t *gui, u32 resized_count);
 void dump_emummc_raw(emmc_tool_gui_t *gui, int part_idx, u32 sector_start, u32 resized_count);
 void update_emummc_base_folder(char *outFilename, u32 sdPathLen, u32 currPartIdx);
 

--- a/nyx/nyx_gui/frontend/gui_emummc_tools.c
+++ b/nyx/nyx_gui/frontend/gui_emummc_tools.c
@@ -35,10 +35,18 @@ typedef struct _mbr_ctxt_t
 	u32 sector_start;
 } mbr_ctxt_t;
 
+#define FILE_EMUMMC_MIN_GIB         4
+#define FILE_EMUMMC_MAX_GIB         28
+#define FILE_EMUMMC_DEFAULT_GIB     5
+#define FILE_EMUMMC_SECTORS_PER_GIB 0x200000
+
 static bool emummc_backup;
 static mbr_ctxt_t mbr_ctx;
 static lv_obj_t *emummc_manage_window;
 static lv_res_t (*emummc_tools)(lv_obj_t *btn);
+static u32 file_resized_count;
+static u32 file_size_gib;
+static lv_obj_t *file_size_label;
 
 static lv_res_t _action_emummc_window_close(lv_obj_t *btn)
 {
@@ -132,7 +140,7 @@ static void _create_window_emummc()
 	emmc_tool_gui_ctxt.label_finish = label_finish;
 
 	if (!mbr_ctx.part_idx)
-		dump_emummc_file(&emmc_tool_gui_ctxt);
+		dump_emummc_file(&emmc_tool_gui_ctxt, file_resized_count);
 	else
 		dump_emummc_raw(&emmc_tool_gui_ctxt, mbr_ctx.part_idx, mbr_ctx.sector_start, mbr_ctx.resized_cnt[mbr_ctx.part_idx - 1]);
 
@@ -193,6 +201,109 @@ static lv_res_t _create_emummc_raw_action(lv_obj_t * btns, const char * txt)
 	nyx_mbox_action(btns, txt);
 
 	return LV_RES_INV;
+}
+
+static lv_res_t _action_slider_file_size(lv_obj_t *slider)
+{
+	char lbl_text[64];
+
+	file_size_gib = lv_slider_get_value(slider);
+	s_printf(lbl_text, "#C7EA46 %d GiB#", file_size_gib);
+	lv_label_set_text(file_size_label, lbl_text);
+
+	return LV_RES_OK;
+}
+
+static lv_res_t _create_emummc_file_size_action(lv_obj_t *btns, const char *txt)
+{
+	int btn_idx = lv_btnm_get_pressed(btns);
+
+	nyx_mbox_action(btns, txt);
+
+	if (!btn_idx)
+	{
+		file_resized_count = file_size_gib * FILE_EMUMMC_SECTORS_PER_GIB;
+		_create_window_emummc();
+	}
+
+	return LV_RES_INV;
+}
+
+static void _create_mbox_emummc_file_size()
+{
+	lv_obj_t *dark_bg = lv_obj_create(lv_scr_act(), NULL);
+	lv_obj_set_style(dark_bg, &mbox_darken);
+	lv_obj_set_size(dark_bg, LV_HOR_RES, LV_VER_RES);
+
+	static const char *mbox_btn_map[] = { "\222Continue", "\222Cancel", "" };
+	lv_obj_t *mbox = lv_mbox_create(dark_bg, NULL);
+	lv_mbox_set_recolor_text(mbox, true);
+	lv_obj_set_width(mbox, LV_HOR_RES / 9 * 5);
+	lv_mbox_set_text(mbox,
+		"#FF8000 SD File emuMMC#\n\n"
+		"Choose resized emuMMC size:");
+
+	file_size_gib = FILE_EMUMMC_DEFAULT_GIB;
+	file_size_label = lv_label_create(mbox, NULL);
+	lv_label_set_recolor(file_size_label, true);
+	lv_label_set_static_text(file_size_label, "#C7EA46 5 GiB#");
+
+	lv_obj_t *slider = lv_slider_create(mbox, NULL);
+	lv_obj_set_size(slider, LV_DPI * 4, LV_DPI / 3);
+	lv_slider_set_range(slider, FILE_EMUMMC_MIN_GIB, FILE_EMUMMC_MAX_GIB);
+	lv_slider_set_value(slider, FILE_EMUMMC_DEFAULT_GIB);
+	lv_slider_set_action(slider, _action_slider_file_size);
+
+	lv_mbox_add_btns(mbox, mbox_btn_map, _create_emummc_file_size_action);
+
+	lv_obj_align(mbox, NULL, LV_ALIGN_CENTER, 0, 0);
+	lv_obj_set_top(mbox, true);
+}
+
+static lv_res_t _create_emummc_file_mode_action(lv_obj_t *btns, const char *txt)
+{
+	int btn_idx = lv_btnm_get_pressed(btns);
+	lv_obj_t *bg = lv_obj_get_parent(lv_obj_get_parent(btns));
+
+	switch (btn_idx)
+	{
+	case 0:
+		file_resized_count = 0;
+		lv_obj_set_style(bg, &lv_style_transp);
+		_create_window_emummc();
+		break;
+	case 1:
+		_create_mbox_emummc_file_size();
+		break;
+	default:
+		break;
+	}
+
+	nyx_mbox_action(btns, txt);
+
+	return LV_RES_INV;
+}
+
+static void _create_mbox_emummc_file()
+{
+	lv_obj_t *dark_bg = lv_obj_create(lv_scr_act(), NULL);
+	lv_obj_set_style(dark_bg, &mbox_darken);
+	lv_obj_set_size(dark_bg, LV_HOR_RES, LV_VER_RES);
+
+	static const char *mbox_btn_map[] = { "\222Full Size", "\222Custom Size", "\222Cancel", "" };
+	lv_obj_t *mbox = lv_mbox_create(dark_bg, NULL);
+	lv_mbox_set_recolor_text(mbox, true);
+	lv_obj_set_width(mbox, LV_HOR_RES / 9 * 6);
+
+	lv_mbox_set_text(mbox,
+		"#FF8000 SD File emuMMC#\n\n"
+		"#C7EA46 Full Size# creates the classic 29/64 GiB file emuMMC.\n"
+		"#C7EA46 Custom Size# creates a resized file emuMMC.");
+
+	lv_mbox_add_btns(mbox, mbox_btn_map, _create_emummc_file_mode_action);
+
+	lv_obj_align(mbox, NULL, LV_ALIGN_CENTER, 0, 0);
+	lv_obj_set_top(mbox, true);
 }
 
 static void _create_mbox_emummc_raw()
@@ -312,7 +423,6 @@ static void _create_mbox_emummc_raw()
 static lv_res_t _create_emummc_action(lv_obj_t * btns, const char * txt)
 {
 	int btn_idx = lv_btnm_get_pressed(btns);
-	lv_obj_t *bg = lv_obj_get_parent(lv_obj_get_parent(btns));
 
 	mbr_ctx.part_idx = 0;
 	mbr_ctx.sector_start = 0;
@@ -320,8 +430,7 @@ static lv_res_t _create_emummc_action(lv_obj_t * btns, const char * txt)
 	switch (btn_idx)
 	{
 	case 0:
-		lv_obj_set_style(bg, &lv_style_transp);
-		_create_window_emummc();
+		_create_mbox_emummc_file();
 		break;
 	case 1:
 		_create_mbox_emummc_raw();


### PR DESCRIPTION
Adds a SD File emuMMC mode popup that lets users choose between the existing full-size file emuMMC behavior and a resized file-based emuMMC size selected with a slider.

The resized path copies only the requested GPP range, formats the resized USER partition through the BIS file backend, updates GPT/MBR metadata, and  preserves the classic full-size SD File flow when selected.


<img width="4000" height="3000" alt="20260808_123721" src="https://github.com/user-attachments/assets/f68a1494-8434-403d-b03f-b01903a12713" />
<img width="4000" height="3000" alt="20260808_123725" src="https://github.com/user-attachments/assets/c9da8d90-81e1-4cf3-aaff-937b73f15b57" />
<img width="4000" height="3000" alt="20260808_123729" src="https://github.com/user-attachments/assets/a0ec94b0-4ce3-4582-b66f-b370b73d8b1b" />
<img width="4000" height="3000" alt="20260808_123735" src="https://github.com/user-attachments/assets/f1a4bf80-9a66-4c74-a420-67e77d97f1cd" />
<img width="4000" height="3000" alt="20260808_123747" src="https://github.com/user-attachments/assets/9e09aeef-ac07-448e-8b31-d32dff713eab" />



